### PR TITLE
Support least-squares baseline solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,81 @@ The command will:
 2. Train the linear baseline with mean squared error.
 3. Save the trained model checkpoint and configuration into the output folder.
 
+When the baseline behaves like a simple linear regression, you can bypass
+iterative optimisation and recover the atomic energy coefficients with a single
+least-squares solve:
+
+```bash
+python -m deltamol.main train-baseline data.npz --solver least_squares
+```
+
+The same `solver` option can be stored inside a YAML configuration alongside
+other training overrides.
+
+Advanced options such as the optimizer family, scheduler, or device can be
+specified via a YAML file and passed to the command with `--config`. Any
+arguments provided on the CLI continue to override the values defined in the
+configuration file, so the most common tweaks remain one flag away:
+
+```yaml
+# baseline.yaml
+output_dir: runs/baseline-adamw
+optimizer: adamw
+weight_decay: 0.01
+scheduler: cosine
+warmup_steps: 500
+min_lr_ratio: 0.2
+device: cuda
+```
+
+```bash
+python -m deltamol.main train-baseline data.npz --config baseline.yaml --epochs 300
+```
+
+### Potential training with configuration files
+
+The `train-potential` subcommand consumes a structured YAML file that describes
+dataset preprocessing, model architecture, and training parameters. Only the
+most important options such as the dataset path and output directory need to be
+specified on the CLI; all other values live alongside the experiment
+definition.
+
+```yaml
+# configs/potential.yaml
+dataset:
+  path: datasets/DFT_uniques.npz
+  cutoff: 6.0
+  dtype: float32
+model:
+  name: transformer
+  hidden_dim: 256
+  num_layers: 6
+  num_heads: 8
+  dropout: 0.1
+  predict_forces: true
+training:
+  output_dir: runs/potential-transformer
+  epochs: 80
+  batch_size: 16
+  learning_rate: 5.0e-4
+  optimizer: adamw
+  scheduler: cosine
+  warmup_steps: 1000
+  force_weight: 0.5
+baseline:
+  checkpoint: runs/baseline/baseline.pt
+```
+
+Launch the run with:
+
+```bash
+python -m deltamol.main train-potential --config configs/potential.yaml
+```
+
+The trainer will configure logging, build the requested model, run the
+experiment, and persist an `experiment.yaml` file in the output directory that
+captures the resolved dataset, model, and training parameters.
+
 ### Descriptor caching
 
 Use the `cache-descriptors` subcommand to precompute descriptor matrices:

--- a/deltamol/config/manager.py
+++ b/deltamol/config/manager.py
@@ -1,9 +1,10 @@
 """Configuration management helpers."""
 from __future__ import annotations
 
-from dataclasses import asdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, fields, is_dataclass
 from pathlib import Path
-from typing import Any, Type, TypeVar
+from typing import Any, Type, TypeVar, Union, get_args, get_origin
 
 try:
     import yaml
@@ -16,10 +17,22 @@ else:
 T = TypeVar("T")
 
 
+def _serialise_value(value: Any) -> Any:
+    """Convert dataclass values to YAML friendly structures."""
+
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {key: _serialise_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_serialise_value(item) for item in value]
+    return value
+
+
 def save_config(config: Any, path: Path) -> None:
     if yaml is None:
         raise ImportError("pyyaml is required to save configs") from _IMPORT_ERROR
-    data = asdict(config)
+    data = _serialise_value(asdict(config) if is_dataclass(config) else config)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=False))
 
@@ -28,4 +41,58 @@ def load_config(path: Path, cls: Type[T]) -> T:
     if yaml is None:
         raise ImportError("pyyaml is required to load configs") from _IMPORT_ERROR
     data = yaml.safe_load(path.read_text())
+    if is_dataclass(cls):
+        if not isinstance(data, Mapping):
+            raise TypeError("Configuration file must contain a mapping at the top level")
+        return _build_dataclass(cls, data)
     return cls(**data)
+
+
+def _build_dataclass(cls: Type[T], data: Mapping[str, Any]) -> T:
+    """Instantiate ``cls`` from the mapping ``data``."""
+
+    kwargs: dict[str, Any] = {}
+    for field in fields(cls):
+        if field.name not in data:
+            continue
+        kwargs[field.name] = _coerce_value(field.type, data[field.name])
+    return cls(**kwargs)
+
+
+def _coerce_value(annotation: Any, value: Any) -> Any:
+    """Convert ``value`` so it matches the provided type annotation."""
+
+    if value is None:
+        return None
+    origin = get_origin(annotation)
+    if origin is None:
+        if annotation is Path:
+            return Path(value)
+        if is_dataclass(annotation) and isinstance(value, Mapping):
+            return _build_dataclass(annotation, value)
+        return value
+    args = get_args(annotation)
+    if origin in (list, Sequence):
+        inner = args[0] if args else Any
+        return [_coerce_value(inner, item) for item in value]
+    if origin is tuple:
+        if len(args) == 2 and args[1] is Ellipsis:
+            inner = args[0]
+            return tuple(_coerce_value(inner, item) for item in value)
+        return tuple(_coerce_value(arg, item) for arg, item in zip(args, value))
+    if origin in (dict, Mapping):
+        key_type, val_type = args if len(args) == 2 else (Any, Any)
+        return {
+            _coerce_value(key_type, key): _coerce_value(val_type, item)
+            for key, item in value.items()
+        }
+    if origin is Union:
+        for option in args:
+            if option is type(None):  # noqa: E721 - Optional detection
+                continue
+            try:
+                return _coerce_value(option, value)
+            except Exception:
+                continue
+        return value
+    return value

--- a/deltamol/main.py
+++ b/deltamol/main.py
@@ -1,8 +1,10 @@
 """High level entry points for DeltaMol."""
 from __future__ import annotations
 
+import logging
+from dataclasses import replace
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 import torch
 
@@ -10,38 +12,69 @@ from .config.manager import save_config
 from .data.io import load_npz_dataset
 from .models.baseline import build_formula_vector
 from .training.pipeline import TrainingConfig, train_baseline
+from .utils.logging import configure_logging
+
+LOGGER = logging.getLogger(__name__)
 
 
 def run_baseline_training(
     dataset_path: Path,
     output_dir: Path,
     *,
-    epochs: int = 200,
-    batch_size: int = 128,
-    learning_rate: float = 1e-2,
-    validation_split: float = 0.1,
+    epochs: Optional[int] = None,
+    batch_size: Optional[int] = None,
+    learning_rate: Optional[float] = None,
+    validation_split: Optional[float] = None,
+    solver: Optional[str] = None,
+    config: TrainingConfig | None = None,
 ) -> None:
     """Train the linear atomic baseline on a dataset."""
 
+    configure_logging(output_dir)
     dataset = load_npz_dataset(dataset_path)
     species = sorted({int(z) for atoms in dataset.atoms for z in atoms})
+    LOGGER.info(
+        "Starting baseline training on %d molecules with %d species",
+        len(dataset.energies),
+        len(species),
+    )
     formula_vectors = torch.stack(
         [build_formula_vector(atoms, species=species) for atoms in dataset.atoms]
     )
     energies = torch.tensor(dataset.energies, dtype=torch.float32)
-    config = TrainingConfig(
-        output_dir=output_dir,
-        epochs=epochs,
-        learning_rate=learning_rate,
-        batch_size=batch_size,
-        validation_split=validation_split,
-    )
+    if config is None:
+        config = TrainingConfig(
+            output_dir=output_dir,
+            epochs=epochs if epochs is not None else 200,
+            learning_rate=learning_rate if learning_rate is not None else 1e-2,
+            batch_size=batch_size if batch_size is not None else 128,
+            validation_split=validation_split if validation_split is not None else 0.1,
+            solver=solver if solver is not None else "optimizer",
+        )
+    else:
+        config = replace(
+            config,
+            output_dir=output_dir,
+            epochs=epochs if epochs is not None else config.epochs,
+            learning_rate=learning_rate if learning_rate is not None else config.learning_rate,
+            batch_size=batch_size if batch_size is not None else config.batch_size,
+            validation_split=(
+                validation_split
+                if validation_split is not None
+                else config.validation_split
+            ),
+            solver=solver if solver is not None else config.solver,
+        )
     trainer = train_baseline(formula_vectors, energies, species=species, config=config)
-    trainer.save_checkpoint(output_dir / "baseline.pt")
+    checkpoint_path = output_dir / "baseline.pt"
+    trainer.save_checkpoint(checkpoint_path)
+    LOGGER.info("Saved baseline checkpoint to %s", checkpoint_path)
     try:
-        save_config(config, output_dir / "config.yaml")
+        config_path = output_dir / "config.yaml"
+        save_config(config, config_path)
+        LOGGER.info("Saved training configuration to %s", config_path)
     except ImportError as exc:
-        print(f"Skipping config serialization: {exc}")
+        LOGGER.warning("Skipping config serialization: %s", exc)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -53,3 +86,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
 
 __all__ = ["main", "run_baseline_training"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
+    main()

--- a/deltamol/models/__init__.py
+++ b/deltamol/models/__init__.py
@@ -1,11 +1,19 @@
 """Model definitions for DeltaMol."""
 from .baseline import LinearAtomicBaseline, LinearBaselineConfig, build_formula_vector
+from .gcn import GCNConfig, GCNPotential
 from .graph import EnergyCorrectionNetwork, GraphModelConfig
+from .potential import PotentialOutput
+from .transformer import TransformerConfig, TransformerPotential
 
 __all__ = [
     "LinearAtomicBaseline",
     "LinearBaselineConfig",
     "build_formula_vector",
+    "GCNConfig",
+    "GCNPotential",
     "EnergyCorrectionNetwork",
     "GraphModelConfig",
+    "PotentialOutput",
+    "TransformerConfig",
+    "TransformerPotential",
 ]

--- a/deltamol/models/gcn.py
+++ b/deltamol/models/gcn.py
@@ -1,0 +1,110 @@
+"""Graph convolutional potential models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+@dataclass
+class GCNConfig:
+    """Configuration for :class:`GCNPotential`."""
+
+    species: Tuple[int, ...]
+    hidden_dim: int = 128
+    num_layers: int = 3
+    dropout: float = 0.1
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+
+
+class GCNLayer(nn.Module):
+    """Lightweight GCN layer operating on dense adjacency matrices."""
+
+    def __init__(self, in_dim: int, out_dim: int, *, dropout: float):
+        super().__init__()
+        self.linear = nn.Linear(in_dim, out_dim)
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, adjacency: torch.Tensor, features: torch.Tensor) -> torch.Tensor:
+        h = torch.matmul(adjacency, features)
+        h = self.linear(h)
+        h = self.activation(h)
+        return self.dropout(h)
+
+
+class GCNPotential(nn.Module):
+    """Predict molecular energies (and optionally forces) with a GCN."""
+
+    def __init__(self, config: GCNConfig):
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+        self.embedding = nn.Embedding(num_species + 1, config.hidden_dim, padding_idx=0)
+        if config.use_coordinate_features:
+            self.coordinate_mlp = nn.Sequential(
+                nn.Linear(3, config.hidden_dim),
+                nn.ReLU(),
+                nn.Linear(config.hidden_dim, config.hidden_dim),
+            )
+        else:
+            self.coordinate_mlp = None
+        layers = []
+        for _ in range(config.num_layers):
+            layers.append(GCNLayer(config.hidden_dim, config.hidden_dim, dropout=config.dropout))
+        self.layers = nn.ModuleList(layers)
+        self.energy_head = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+        if config.predict_forces:
+            self.force_head = nn.Linear(config.hidden_dim, 3)
+        else:
+            self.force_head = None
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask = mask.bool()
+        mask_float = mask.float()
+        adj = self._normalize_adjacency(adjacency, mask_float)
+        h = self.embedding(node_indices)
+        if self.coordinate_mlp is not None:
+            h = h + self.coordinate_mlp(positions)
+        for layer in self.layers:
+            h = layer(adj, h)
+        pooled = self._masked_mean(h, mask_float)
+        energy = self.energy_head(pooled).squeeze(-1)
+        forces = None
+        if self.force_head is not None:
+            forces = self.force_head(h) * mask_float.unsqueeze(-1)
+        return PotentialOutput(energy=energy, forces=forces)
+
+    def _normalize_adjacency(self, adjacency: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        eye = torch.eye(adjacency.size(-1), device=adjacency.device).unsqueeze(0)
+        adjacency = adjacency * mask.unsqueeze(1) * mask.unsqueeze(2)
+        adjacency = adjacency + eye * mask.unsqueeze(-1)
+        degree = adjacency.sum(dim=-1)
+        inv_sqrt_degree = degree.clamp(min=1e-6).pow(-0.5)
+        inv_sqrt_degree = inv_sqrt_degree * mask
+        norm = adjacency * inv_sqrt_degree.unsqueeze(-1) * inv_sqrt_degree.unsqueeze(-2)
+        return norm
+
+    def _masked_mean(self, tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        masked = tensor * mask.unsqueeze(-1)
+        denom = mask.sum(dim=1, keepdim=True).clamp(min=1.0)
+        return masked.sum(dim=1) / denom
+
+
+__all__ = ["GCNConfig", "GCNPotential"]
+

--- a/deltamol/models/potential.py
+++ b/deltamol/models/potential.py
@@ -1,0 +1,18 @@
+"""Shared utilities for potential energy models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class PotentialOutput:
+    """Container holding predictions from a potential model."""
+
+    energy: torch.Tensor
+    forces: torch.Tensor | None = None
+
+
+__all__ = ["PotentialOutput"]
+

--- a/deltamol/models/transformer.py
+++ b/deltamol/models/transformer.py
@@ -1,0 +1,90 @@
+"""Transformer-based potential energy model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+@dataclass
+class TransformerConfig:
+    """Configuration options for :class:`TransformerPotential`."""
+
+    species: Tuple[int, ...]
+    hidden_dim: int = 128
+    num_layers: int = 4
+    num_heads: int = 8
+    dropout: float = 0.1
+    ffn_dim: int = 256
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+
+
+class TransformerPotential(nn.Module):
+    """Encode atom-wise features with a Transformer encoder."""
+
+    def __init__(self, config: TransformerConfig):
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+        self.embedding = nn.Embedding(num_species + 1, config.hidden_dim, padding_idx=0)
+        if config.use_coordinate_features:
+            self.coordinate_mlp = nn.Sequential(
+                nn.Linear(3, config.hidden_dim),
+                nn.ReLU(),
+                nn.Linear(config.hidden_dim, config.hidden_dim),
+            )
+        else:
+            self.coordinate_mlp = None
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.hidden_dim,
+            nhead=config.num_heads,
+            dim_feedforward=config.ffn_dim,
+            dropout=config.dropout,
+            batch_first=True,
+            activation="gelu",
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=config.num_layers)
+        self.energy_head = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+        if config.predict_forces:
+            self.force_head = nn.Linear(config.hidden_dim, 3)
+        else:
+            self.force_head = None
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor,  # kept for API parity, not used directly
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask = mask.bool()
+        mask_float = mask.float()
+        x = self.embedding(node_indices)
+        if self.coordinate_mlp is not None:
+            x = x + self.coordinate_mlp(positions)
+        encoded = self.encoder(x, src_key_padding_mask=~mask)
+        pooled = self._masked_mean(encoded, mask_float)
+        energy = self.energy_head(pooled).squeeze(-1)
+        forces = None
+        if self.force_head is not None:
+            forces = self.force_head(encoded) * mask_float.unsqueeze(-1)
+        return PotentialOutput(energy=energy, forces=forces)
+
+    def _masked_mean(self, tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        masked = tensor * mask.unsqueeze(-1)
+        denom = mask.sum(dim=1, keepdim=True).clamp(min=1.0)
+        return masked.sum(dim=1) / denom
+
+
+__all__ = ["TransformerConfig", "TransformerPotential"]
+

--- a/deltamol/training/__init__.py
+++ b/deltamol/training/__init__.py
@@ -1,9 +1,29 @@
 """Training utilities for DeltaMol."""
-from .pipeline import TensorDataset, Trainer, TrainingConfig, train_baseline
+from .configs import BaselineConfig, DatasetConfig, ModelConfig, PotentialExperimentConfig
+from .datasets import MolecularGraph, MolecularGraphDataset, collate_graphs
+from .pipeline import (
+    PotentialTrainer,
+    PotentialTrainingConfig,
+    TensorDataset,
+    Trainer,
+    TrainingConfig,
+    train_baseline,
+    train_potential_model,
+)
 
 __all__ = [
+    "BaselineConfig",
+    "DatasetConfig",
+    "ModelConfig",
+    "MolecularGraph",
+    "MolecularGraphDataset",
+    "PotentialTrainer",
+    "PotentialTrainingConfig",
+    "PotentialExperimentConfig",
     "TensorDataset",
     "Trainer",
     "TrainingConfig",
+    "collate_graphs",
     "train_baseline",
+    "train_potential_model",
 ]

--- a/deltamol/training/configs.py
+++ b/deltamol/training/configs.py
@@ -1,0 +1,59 @@
+"""Dataclasses describing configurable training components."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .pipeline import PotentialTrainingConfig
+
+
+@dataclass
+class DatasetConfig:
+    """Options that control dataset preparation for potential training."""
+
+    path: Optional[Path] = None
+    cutoff: float = 5.0
+    dtype: str = "float32"
+    species: Optional[Tuple[int, ...]] = None
+
+
+@dataclass
+class BaselineConfig:
+    """Configuration describing a precomputed linear baseline model."""
+
+    checkpoint: Optional[Path] = None
+    species: Optional[Tuple[int, ...]] = None
+
+
+@dataclass
+class ModelConfig:
+    """Lightweight description of the neural potential to construct."""
+
+    name: str = "gcn"
+    hidden_dim: int = 128
+    num_layers: int = 3
+    dropout: float = 0.1
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+    num_heads: int = 8
+    ffn_dim: int = 256
+
+
+@dataclass
+class PotentialExperimentConfig:
+    """Bundle dataset, model, and training configuration together."""
+
+    training: PotentialTrainingConfig
+    model: ModelConfig
+    dataset: DatasetConfig = field(default_factory=DatasetConfig)
+    baseline: Optional[BaselineConfig] = None
+
+
+__all__ = [
+    "BaselineConfig",
+    "DatasetConfig",
+    "ModelConfig",
+    "PotentialExperimentConfig",
+]
+

--- a/deltamol/training/datasets.py
+++ b/deltamol/training/datasets.py
@@ -1,0 +1,140 @@
+"""Dataset helpers for potential energy training."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from ..data.io import MolecularDataset
+from ..models.baseline import build_formula_vector
+
+
+@dataclass
+class MolecularGraph:
+    """Lightweight container describing a single molecular geometry."""
+
+    node_indices: torch.Tensor
+    positions: torch.Tensor
+    adjacency: torch.Tensor
+    energy: torch.Tensor
+    formula_vector: torch.Tensor
+    forces: Optional[torch.Tensor] = None
+
+
+class MolecularGraphDataset(Dataset):
+    """Construct dense graph representations from :class:`MolecularDataset`."""
+
+    def __init__(
+        self,
+        dataset: MolecularDataset,
+        *,
+        species: Optional[Sequence[int]] = None,
+        cutoff: float = 5.0,
+        dtype: Union[torch.dtype, str] = torch.float32,
+    ) -> None:
+        self.cutoff = cutoff
+        if species is None:
+            unique_species = {int(z) for atoms in dataset.atoms for z in atoms}
+            species = tuple(sorted(unique_species))
+        self.species: Tuple[int, ...] = tuple(int(z) for z in species)
+        if isinstance(dtype, str):
+            try:
+                dtype = getattr(torch, dtype)
+            except AttributeError as exc:
+                raise ValueError(f"Unknown dtype string '{dtype}'") from exc
+            if not isinstance(dtype, torch.dtype):
+                raise ValueError(f"Resolved dtype '{dtype}' is not a torch.dtype")
+        self.dtype = dtype
+        self.index_map: Dict[int, int] = {z: i + 1 for i, z in enumerate(self.species)}
+        self.has_forces = dataset.forces is not None
+        self.graphs: List[MolecularGraph] = []
+        for i, atoms in enumerate(dataset.atoms):
+            coordinates = dataset.coordinates[i]
+            energy = dataset.energies[i] if dataset.energies is not None else 0.0
+            graph = self._build_graph(atoms, coordinates, energy, dataset.forces[i] if self.has_forces else None)
+            self.graphs.append(graph)
+
+    def _atoms_to_indices(self, atoms: Iterable[int]) -> torch.Tensor:
+        indices = [self.index_map[int(z)] for z in atoms]
+        return torch.tensor(indices, dtype=torch.long)
+
+    def _build_adjacency(self, positions: torch.Tensor) -> torch.Tensor:
+        distances = torch.cdist(positions, positions)
+        adjacency = (distances < self.cutoff).float()
+        adjacency.fill_diagonal_(0.0)
+        return adjacency
+
+    def _build_graph(
+        self,
+        atoms: np.ndarray,
+        coordinates: np.ndarray,
+        energy: float,
+        forces: Optional[np.ndarray],
+    ) -> MolecularGraph:
+        node_indices = self._atoms_to_indices(atoms)
+        positions_array = np.asarray(coordinates, dtype=float)
+        positions = torch.tensor(positions_array, dtype=self.dtype)
+        adjacency = self._build_adjacency(positions)
+        energy_tensor = torch.tensor(float(energy), dtype=self.dtype)
+        formula_vector = build_formula_vector(atoms, species=self.species).to(self.dtype)
+        forces_tensor = None
+        if forces is not None:
+            forces_tensor = torch.tensor(np.asarray(forces, dtype=float), dtype=self.dtype)
+        return MolecularGraph(
+            node_indices=node_indices,
+            positions=positions,
+            adjacency=adjacency,
+            energy=energy_tensor,
+            formula_vector=formula_vector,
+            forces=forces_tensor,
+        )
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.graphs)
+
+    def __getitem__(self, index: int) -> MolecularGraph:
+        return self.graphs[index]
+
+
+def collate_graphs(batch: Sequence[MolecularGraph]) -> Dict[str, torch.Tensor]:
+    """Pad a batch of :class:`MolecularGraph` objects into dense tensors."""
+
+    batch_size = len(batch)
+    max_nodes = max(graph.node_indices.numel() for graph in batch)
+    feature_dim = batch[0].formula_vector.numel()
+    node_indices = torch.zeros(batch_size, max_nodes, dtype=torch.long)
+    positions = torch.zeros(batch_size, max_nodes, 3, dtype=batch[0].positions.dtype)
+    adjacency = torch.zeros(batch_size, max_nodes, max_nodes, dtype=batch[0].adjacency.dtype)
+    mask = torch.zeros(batch_size, max_nodes, dtype=torch.bool)
+    formula_vectors = torch.zeros(batch_size, feature_dim, dtype=batch[0].formula_vector.dtype)
+    energies = torch.zeros(batch_size, dtype=batch[0].energy.dtype)
+    has_forces = batch[0].forces is not None
+    forces = torch.zeros(batch_size, max_nodes, 3, dtype=batch[0].positions.dtype) if has_forces else None
+    for i, graph in enumerate(batch):
+        n = graph.node_indices.numel()
+        node_indices[i, :n] = graph.node_indices
+        positions[i, :n] = graph.positions
+        adjacency[i, :n, :n] = graph.adjacency
+        mask[i, :n] = True
+        formula_vectors[i] = graph.formula_vector
+        energies[i] = graph.energy
+        if has_forces and graph.forces is not None:
+            forces[i, :n] = graph.forces
+    batch_dict = {
+        "node_indices": node_indices,
+        "positions": positions,
+        "adjacency": adjacency,
+        "mask": mask,
+        "energies": energies,
+        "formula_vectors": formula_vectors,
+    }
+    if has_forces:
+        batch_dict["forces"] = forces
+    return batch_dict
+
+
+__all__ = ["MolecularGraph", "MolecularGraphDataset", "collate_graphs"]
+

--- a/deltamol/training/pipeline.py
+++ b/deltamol/training/pipeline.py
@@ -1,15 +1,182 @@
 """High level training orchestration utilities."""
 from __future__ import annotations
 
+import json
+import logging
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Sequence
 
 import torch
 from torch import nn
+from torch.optim import Optimizer
 from torch.utils.data import DataLoader, Dataset, random_split
 
 from ..models.baseline import LinearAtomicBaseline, LinearBaselineConfig
+from ..models.potential import PotentialOutput
+from .datasets import MolecularGraphDataset, collate_graphs
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _emit_info(message: str) -> None:
+    """Emit an informational message via logging with stdout fallback."""
+
+    LOGGER.info(message)
+    if not (LOGGER.hasHandlers() and LOGGER.isEnabledFor(logging.INFO)):
+        print(message)
+
+
+def _save_history(output_dir: Path, history: Dict[str, float]) -> Path:
+    """Persist a training history dictionary to ``history.json``."""
+
+    history_path = output_dir / "history.json"
+    with history_path.open("w", encoding="utf-8") as handle:
+        json.dump(history, handle, indent=2)
+    _emit_info(f"Saved training history to {history_path}")
+    return history_path
+
+
+class WarmupDecayScheduler:
+    """Learning rate scheduler with warmup and configurable decay."""
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        *,
+        warmup_steps: int,
+        total_steps: int,
+        strategy: str,
+        min_lr_ratio: float,
+        gamma: float,
+        step_size: int,
+    ) -> None:
+        self.optimizer = optimizer
+        self.strategy = strategy
+        self.warmup_steps = max(int(warmup_steps), 0)
+        inferred_total = max(int(total_steps), 1)
+        self.total_steps = max(inferred_total, self.warmup_steps + 1)
+        self.min_lr_ratio = max(float(min_lr_ratio), 0.0)
+        self.gamma = float(gamma)
+        self.step_size = max(int(step_size), 1)
+        self.base_lrs = [group["lr"] for group in optimizer.param_groups]
+        self.current_step = 0
+        self.last_lrs = list(self.base_lrs)
+        self._apply_lrs()
+
+    def state_dict(self) -> Dict[str, object]:
+        return {
+            "current_step": self.current_step,
+            "last_lrs": list(self.last_lrs),
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, object]) -> None:
+        self.current_step = int(state_dict.get("current_step", 0))
+        self._apply_lrs()
+
+    def step(self) -> None:
+        if self.current_step < self.total_steps - 1:
+            self.current_step += 1
+        self._apply_lrs()
+
+    def _apply_lrs(self) -> None:
+        factor = self._compute_factor(self.current_step)
+        self.last_lrs = []
+        for base_lr, group in zip(self.base_lrs, self.optimizer.param_groups):
+            new_lr = base_lr * factor
+            group["lr"] = new_lr
+            self.last_lrs.append(new_lr)
+
+    def _compute_factor(self, step: int) -> float:
+        if self.total_steps <= 1:
+            return 1.0
+        if step < self.warmup_steps:
+            return (step + 1) / max(1, self.warmup_steps)
+        decay_steps = self.total_steps - self.warmup_steps
+        if decay_steps <= 1:
+            return 1.0
+        progress = (step - self.warmup_steps) / max(decay_steps - 1, 1)
+        progress = min(max(progress, 0.0), 1.0)
+        if self.strategy == "linear":
+            value = 1.0 - (1.0 - self.min_lr_ratio) * progress
+        elif self.strategy == "cosine":
+            value = self.min_lr_ratio + (1.0 - self.min_lr_ratio) * 0.5 * (
+                1.0 + math.cos(math.pi * progress)
+            )
+        elif self.strategy == "exponential":
+            exponent = max(step - self.warmup_steps, 0)
+            value = self.gamma**exponent
+        elif self.strategy == "step":
+            exponent = max(step - self.warmup_steps, 0) // self.step_size
+            value = self.gamma**exponent
+        elif self.strategy == "constant":
+            value = 1.0
+        else:  # pragma: no cover - guarded by validation
+            raise ValueError(f"Unknown scheduler strategy: {self.strategy}")
+        return max(value, self.min_lr_ratio)
+
+    def get_last_lr(self) -> Sequence[float]:
+        return list(self.last_lrs)
+
+
+def _build_optimizer(parameters, config: TrainingConfig) -> Optimizer:
+    name = config.optimizer.lower()
+    if name == "adam":
+        return torch.optim.Adam(
+            parameters,
+            lr=config.learning_rate,
+            betas=(config.beta1, config.beta2),
+            eps=config.eps,
+            weight_decay=config.weight_decay,
+            amsgrad=config.amsgrad,
+        )
+    if name == "adamw":
+        return torch.optim.AdamW(
+            parameters,
+            lr=config.learning_rate,
+            betas=(config.beta1, config.beta2),
+            eps=config.eps,
+            weight_decay=config.weight_decay,
+            amsgrad=config.amsgrad,
+        )
+    if name == "sgd":
+        return torch.optim.SGD(
+            parameters,
+            lr=config.learning_rate,
+            momentum=config.momentum,
+            weight_decay=config.weight_decay,
+            nesterov=config.nesterov,
+        )
+    raise ValueError(f"Unsupported optimizer '{config.optimizer}'")
+
+
+def _maybe_build_scheduler(
+    optimizer: Optimizer, config: TrainingConfig, steps_per_epoch: Optional[int]
+) -> Optional[WarmupDecayScheduler]:
+    strategy = (config.scheduler or "").lower()
+    if not strategy:
+        return None
+    supported = {"linear", "cosine", "exponential", "step", "constant"}
+    if strategy not in supported:
+        raise ValueError(f"Unsupported scheduler '{config.scheduler}'")
+    if config.scheduler_total_steps is not None:
+        total_steps = int(config.scheduler_total_steps)
+    elif steps_per_epoch is not None:
+        total_steps = steps_per_epoch * max(config.epochs, 1)
+    else:
+        return None
+    if total_steps <= 0:
+        return None
+    return WarmupDecayScheduler(
+        optimizer,
+        warmup_steps=config.warmup_steps,
+        total_steps=total_steps,
+        strategy=strategy,
+        min_lr_ratio=config.min_lr_ratio,
+        gamma=config.scheduler_gamma,
+        step_size=config.scheduler_step_size,
+    )
 
 
 @dataclass
@@ -21,6 +188,21 @@ class TrainingConfig:
     log_every: int = 10
     device: str = "auto"
     validation_split: float = 0.1
+    optimizer: str = "adam"
+    weight_decay: float = 0.0
+    beta1: float = 0.9
+    beta2: float = 0.999
+    eps: float = 1e-8
+    amsgrad: bool = False
+    momentum: float = 0.9
+    nesterov: bool = False
+    solver: str = "optimizer"
+    scheduler: Optional[str] = None
+    warmup_steps: int = 0
+    min_lr_ratio: float = 0.0
+    scheduler_gamma: float = 0.1
+    scheduler_step_size: int = 1000
+    scheduler_total_steps: Optional[int] = None
 
 
 class Trainer:
@@ -31,10 +213,12 @@ class Trainer:
         self.config = config
         self.device = self._resolve_device(config.device)
         self.model.to(self.device)
-        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=config.learning_rate)
+        self.optimizer = _build_optimizer(self.model.parameters(), config)
+        self.scheduler: Optional[WarmupDecayScheduler] = None
         self.criterion = nn.MSELoss()
         self.output_dir = config.output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.history: Dict[str, float] = {}
 
     def _resolve_device(self, device: str) -> torch.device:
         if device == "auto":
@@ -47,15 +231,40 @@ class Trainer:
 
     def train(self, dataloader: DataLoader, *, val_loader: Optional[DataLoader] = None) -> Dict[str, float]:
         history: Dict[str, float] = {}
+        train_samples = len(getattr(dataloader, "dataset", []))
+        val_samples = len(getattr(val_loader, "dataset", [])) if val_loader is not None else 0
+        try:
+            steps_per_epoch = len(dataloader)
+        except TypeError:
+            steps_per_epoch = None
+        self.scheduler = _maybe_build_scheduler(self.optimizer, self.config, steps_per_epoch)
+        summary = f"Starting training for {self.config.epochs} epochs on {train_samples} samples"
+        if val_loader is not None:
+            summary += f" with {val_samples} validation samples"
+        summary += f" | optimizer={self.config.optimizer}"
+        if self.scheduler is not None:
+            summary += f", scheduler={self.config.scheduler}"
+            if self.config.warmup_steps > 0:
+                summary += f" (warmup={self.config.warmup_steps})"
+        _emit_info(summary)
+        log_interval = max(int(self.config.log_every), 1)
         for epoch in range(1, self.config.epochs + 1):
             train_loss = self._run_epoch(dataloader, training=True)
             history[f"train/{epoch}"] = train_loss
+            val_loss: Optional[float] = None
             if val_loader is not None:
                 val_loss = self._run_epoch(val_loader, training=False)
                 history[f"val/{epoch}"] = val_loss
-            if epoch % self.config.log_every == 0:
-                print(f"Epoch {epoch:03d} | train: {train_loss:.4f}"
-                      + (f" | val: {val_loss:.4f}" if val_loader is not None else ""))
+            if epoch == 1 or epoch == self.config.epochs or epoch % log_interval == 0:
+                message = f"Epoch {epoch:03d} | train: {train_loss:.4f}"
+                if val_loss is not None:
+                    message += f" | val: {val_loss:.4f}"
+                _emit_info(message)
+            if self.scheduler is not None:
+                lr_value = float(self.scheduler.get_last_lr()[0])
+                history[f"lr/{epoch}"] = lr_value
+        self.history = history
+        _save_history(self.output_dir, history)
         return history
 
     def _run_epoch(self, dataloader: DataLoader, *, training: bool) -> float:
@@ -73,6 +282,8 @@ class Trainer:
             if training:
                 loss.backward()
                 self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
             total_loss += loss.item()
             n_batches += 1
         return total_loss / max(n_batches, 1)
@@ -98,19 +309,295 @@ class TensorDataset(Dataset):
         return self.inputs[index], self.targets[index]
 
 
-def train_baseline(formula_vectors: torch.Tensor, energies: torch.Tensor, *, species: Sequence[int], config: TrainingConfig) -> Trainer:
+def _solve_least_squares(
+    model: LinearAtomicBaseline,
+    dataset: TensorDataset,
+    *,
+    train_indices: Sequence[int],
+    val_indices: Sequence[int],
+    output_dir: Path,
+) -> Dict[str, float]:
+    train_indices = list(train_indices)
+    val_indices = list(val_indices)
+    if not train_indices:
+        raise ValueError("Least squares solver requires at least one training sample")
+    train_inputs = dataset.inputs[train_indices]
+    train_targets = dataset.targets[train_indices]
+    _emit_info(
+        "Fitting baseline with closed-form least squares on %d samples%s"
+        % (
+            len(train_indices),
+            f" and {len(val_indices)} validation samples" if val_indices else "",
+        )
+    )
+    with torch.no_grad():
+        solution = torch.linalg.lstsq(
+            train_inputs.to(torch.float64), train_targets.to(torch.float64).unsqueeze(-1)
+        ).solution.squeeze(-1)
+        model.linear.weight.data.copy_(solution.to(train_inputs.dtype).unsqueeze(0))
+    history: Dict[str, float] = {}
+    with torch.no_grad():
+        train_predictions = model(train_inputs)
+        train_loss = torch.mean((train_predictions - train_targets) ** 2).item()
+        history["train/1"] = train_loss
+        if val_indices:
+            val_inputs = dataset.inputs[val_indices]
+            val_targets = dataset.targets[val_indices]
+            val_predictions = model(val_inputs)
+            val_loss = torch.mean((val_predictions - val_targets) ** 2).item()
+            history["val/1"] = val_loss
+    message = f"Least squares fit | train: {train_loss:.4f}"
+    if "val/1" in history:
+        message += f" | val: {history['val/1']:.4f}"
+    _emit_info(message)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _save_history(output_dir, history)
+    return history
+
+
+def train_baseline(
+    formula_vectors: torch.Tensor,
+    energies: torch.Tensor,
+    *,
+    species: Sequence[int],
+    config: TrainingConfig,
+) -> Trainer:
     dataset = TensorDataset(formula_vectors, energies)
     val_size = int(len(dataset) * config.validation_split)
     if val_size > 0:
         train_size = len(dataset) - val_size
         train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
         val_loader = DataLoader(val_dataset, batch_size=config.batch_size, shuffle=False)
+        train_indices = list(train_dataset.indices)  # type: ignore[attr-defined]
+        val_indices = list(val_dataset.indices)  # type: ignore[attr-defined]
     else:
         train_dataset = dataset
         val_loader = None
-    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=True)
+        train_indices = list(range(len(dataset)))
+        val_indices = []
     baseline_config = LinearBaselineConfig(species=tuple(species))
     model = LinearAtomicBaseline(baseline_config)
+    solver = getattr(config, "solver", "optimizer").lower()
+    if solver in {"least_squares", "ols", "linear_regression"}:
+        history = _solve_least_squares(
+            model,
+            dataset,
+            train_indices=train_indices,
+            val_indices=val_indices,
+            output_dir=config.output_dir,
+        )
+        trainer = Trainer(model, config)
+        trainer.history = history
+        return trainer
+    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=True)
     trainer = Trainer(model, config)
+    trainer.train(train_loader, val_loader=val_loader)
+    return trainer
+
+
+@dataclass
+class PotentialTrainingConfig(TrainingConfig):
+    """Configuration for potential energy/force training."""
+
+    energy_weight: float = 1.0
+    force_weight: float = 0.0
+    predict_forces_directly: bool = False
+    max_grad_norm: Optional[float] = None
+
+
+class PotentialTrainer:
+    """Trainer that optimizes potential models for energies and forces."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        config: PotentialTrainingConfig,
+        *,
+        baseline: Optional[LinearAtomicBaseline] = None,
+    ) -> None:
+        self.model = model
+        self.config = config
+        self.device = self._resolve_device(config.device)
+        self.model.to(self.device)
+        self.optimizer = _build_optimizer(self.model.parameters(), config)
+        self.scheduler: Optional[WarmupDecayScheduler] = None
+        self.energy_loss = nn.MSELoss()
+        self.force_loss = nn.MSELoss()
+        self.output_dir = config.output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.baseline = baseline
+        self.history: Dict[str, float] = {}
+        if self.baseline is not None:
+            self.baseline.to(self.device)
+            self.baseline.eval()
+            for param in self.baseline.parameters():
+                param.requires_grad_(False)
+
+    def _resolve_device(self, device: str) -> torch.device:
+        if device == "auto":
+            if torch.cuda.is_available():
+                return torch.device("cuda")
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                return torch.device("mps")
+            return torch.device("cpu")
+        return torch.device(device)
+
+    def train(self, dataloader: DataLoader, *, val_loader: Optional[DataLoader] = None) -> Dict[str, float]:
+        history: Dict[str, float] = {}
+        train_samples = len(getattr(dataloader, "dataset", []))
+        val_samples = len(getattr(val_loader, "dataset", [])) if val_loader is not None else 0
+        summary = (
+            f"Starting potential training for {self.config.epochs} epochs on {train_samples} samples"
+        )
+        if val_loader is not None:
+            summary += f" with {val_samples} validation samples"
+        details = [f"energy weight={self.config.energy_weight}"]
+        if self.config.force_weight > 0.0:
+            details.append(f"force weight={self.config.force_weight}")
+            if self.config.predict_forces_directly:
+                details.append("predicting forces directly")
+        try:
+            steps_per_epoch = len(dataloader)
+        except TypeError:
+            steps_per_epoch = None
+        self.scheduler = _maybe_build_scheduler(self.optimizer, self.config, steps_per_epoch)
+        details.append(f"optimizer={self.config.optimizer}")
+        if self.scheduler is not None:
+            schedule_msg = f"scheduler={self.config.scheduler}"
+            if self.config.warmup_steps > 0:
+                schedule_msg += f" (warmup={self.config.warmup_steps})"
+            details.append(schedule_msg)
+        if details:
+            summary += " (" + ", ".join(details) + ")"
+        _emit_info(summary)
+        log_interval = max(int(self.config.log_every), 1)
+        for epoch in range(1, self.config.epochs + 1):
+            train_metrics = self._run_epoch(dataloader, training=True)
+            history[f"train/{epoch}"] = train_metrics["loss"]
+            val_metrics: Optional[Dict[str, float]] = None
+            if val_loader is not None:
+                val_metrics = self._run_epoch(val_loader, training=False)
+                history[f"val/{epoch}"] = val_metrics["loss"]
+            if epoch == 1 or epoch == self.config.epochs or epoch % log_interval == 0:
+                message = f"Epoch {epoch:03d} | train: {train_metrics['loss']:.4f}"
+                if val_metrics is not None:
+                    message += f" | val: {val_metrics['loss']:.4f}"
+                _emit_info(message)
+            if self.scheduler is not None:
+                history[f"lr/{epoch}"] = float(self.scheduler.get_last_lr()[0])
+        self.history = history
+        _save_history(self.output_dir, history)
+        return history
+
+    def _run_epoch(self, dataloader: DataLoader, *, training: bool) -> Dict[str, float]:
+        self.model.train(mode=training)
+        total_loss = 0.0
+        total_energy_loss = 0.0
+        total_force_loss = 0.0
+        n_batches = 0
+        for batch in dataloader:
+            batch = {key: value.to(self.device) for key, value in batch.items() if isinstance(value, torch.Tensor)}
+            energies = batch["energies"]
+            formula_vectors = batch["formula_vectors"]
+            baseline_energy = None
+            if self.baseline is not None:
+                with torch.no_grad():
+                    baseline_energy = self.baseline(formula_vectors).detach()
+                target_energy = energies - baseline_energy
+            else:
+                target_energy = energies
+            requires_force_grad = (
+                self.config.force_weight > 0.0
+                and not self.config.predict_forces_directly
+                and batch.get("forces") is not None
+            )
+            positions = batch["positions"]
+            if requires_force_grad:
+                positions = positions.clone().detach().requires_grad_(True)
+                batch["positions"] = positions
+            self.optimizer.zero_grad(set_to_none=True)
+            with torch.set_grad_enabled(training or requires_force_grad):
+                output = self._forward_model(batch)
+                energy_pred = output.energy
+                energy_loss = self.energy_loss(energy_pred, target_energy)
+                loss = self.config.energy_weight * energy_loss
+                force_loss_value = torch.tensor(0.0, device=self.device)
+                if batch.get("forces") is not None and self.config.force_weight > 0.0:
+                    if output.forces is not None and self.config.predict_forces_directly:
+                        predicted_forces = output.forces
+                    else:
+                        grads = torch.autograd.grad(
+                            energy_pred.sum(),
+                            positions,
+                            create_graph=training,
+                            retain_graph=training,
+                        )[0]
+                        predicted_forces = -grads
+                    mask = batch["mask"].unsqueeze(-1)
+                    target_forces = batch["forces"] * mask
+                    predicted_forces = predicted_forces * mask
+                    force_loss_value = self.force_loss(predicted_forces, target_forces)
+                    loss = loss + self.config.force_weight * force_loss_value
+            if training:
+                loss.backward()
+                if self.config.max_grad_norm is not None:
+                    nn.utils.clip_grad_norm_(self.model.parameters(), self.config.max_grad_norm)
+                self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
+            total_loss += loss.item()
+            total_energy_loss += energy_loss.item()
+            total_force_loss += force_loss_value.item()
+            n_batches += 1
+        metrics = {
+            "loss": total_loss / max(n_batches, 1),
+            "energy_loss": total_energy_loss / max(n_batches, 1),
+        }
+        if self.config.force_weight > 0.0:
+            metrics["force_loss"] = total_force_loss / max(n_batches, 1)
+        return metrics
+
+    def _forward_model(self, batch: Dict[str, torch.Tensor]) -> PotentialOutput:
+        return self.model(
+            batch["node_indices"],
+            batch["positions"],
+            batch["adjacency"],
+            batch["mask"],
+        )
+
+    def save_checkpoint(self, path: Path) -> None:
+        torch.save({
+            "model_state": self.model.state_dict(),
+            "config": self.config,
+        }, path)
+
+
+def train_potential_model(
+    dataset: MolecularGraphDataset,
+    model: nn.Module,
+    *,
+    config: PotentialTrainingConfig,
+    baseline: Optional[LinearAtomicBaseline] = None,
+) -> PotentialTrainer:
+    val_size = int(len(dataset) * config.validation_split)
+    if val_size > 0:
+        train_size = len(dataset) - val_size
+        train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=config.batch_size,
+            shuffle=False,
+            collate_fn=collate_graphs,
+        )
+    else:
+        train_dataset = dataset
+        val_loader = None
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=config.batch_size,
+        shuffle=True,
+        collate_fn=collate_graphs,
+    )
+    trainer = PotentialTrainer(model, config, baseline=baseline)
     trainer.train(train_loader, val_loader=val_loader)
     return trainer

--- a/deltamol/utils/logging.py
+++ b/deltamol/utils/logging.py
@@ -15,4 +15,5 @@ def configure_logging(output_dir: Path, level: int = logging.INFO) -> None:
             logging.FileHandler(log_path),
             logging.StreamHandler(),
         ],
+        force=True,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from deltamol.config.manager import load_config, save_config
+
+
+@dataclass
+class InnerConfig:
+    path: Path
+    values: tuple[int, ...]
+
+
+@dataclass
+class OuterConfig:
+    inner: InnerConfig
+    names: tuple[str, ...]
+
+
+def test_nested_config_roundtrip(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    original = OuterConfig(
+        inner=InnerConfig(path=tmp_path / "data", values=(1, 2, 3)),
+        names=("alpha", "beta"),
+    )
+
+    save_config(original, config_path)
+    loaded = load_config(config_path, OuterConfig)
+
+    assert loaded == original

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,11 @@
 import numpy as np
 import pytest
 
+torch = pytest.importorskip("torch")
+
 from deltamol.data.io import load_npz_dataset
+from deltamol.data.io import MolecularDataset
+from deltamol.training.datasets import MolecularGraphDataset, collate_graphs
 
 
 def test_load_npz_dataset(tmp_path):
@@ -24,3 +28,42 @@ def test_load_npz_dataset(tmp_path):
     assert dataset.coordinates.shape[0] == 2
     assert dataset.energies.tolist() == pytest.approx([-76.4, -40.2], abs=1e-5)
     assert dataset.metadata["split"].tolist() == [1, 2]
+
+
+def test_molecular_graph_dataset_and_collate():
+    atoms = np.array([
+        np.array([1, 8, 1]),
+        np.array([6, 1]),
+    ], dtype=object)
+    coordinates = np.array([
+        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.9, -0.3]], dtype=np.float32),
+        np.array([[0.0, 0.0, 0.0], [1.1, 0.0, 0.0]], dtype=np.float32),
+    ], dtype=object)
+    energies = np.array([-76.4, -40.2], dtype=np.float32)
+    forces = np.array([
+        np.zeros((3, 3), dtype=np.float32),
+        np.zeros((2, 3), dtype=np.float32),
+    ], dtype=object)
+    dataset = MolecularDataset(atoms=atoms, coordinates=coordinates, energies=energies, forces=forces)
+
+    graph_dataset = MolecularGraphDataset(dataset, cutoff=2.5)
+    batch = collate_graphs([graph_dataset[0], graph_dataset[1]])
+
+    assert batch["node_indices"].shape == (2, 3)
+    assert batch["positions"].shape[-1] == 3
+    assert batch["mask"].dtype == torch.bool
+    assert torch.allclose(batch["energies"], torch.tensor([-76.4, -40.2]))
+    assert "forces" in batch
+    assert batch["forces"].shape == (2, 3, 3)
+
+
+def test_molecular_graph_dataset_accepts_string_dtype():
+    atoms = np.array([np.array([1, 1])], dtype=object)
+    coordinates = np.array([np.zeros((2, 3), dtype=np.float32)], dtype=object)
+    energies = np.array([-1.23], dtype=np.float32)
+    dataset = MolecularDataset(atoms=atoms, coordinates=coordinates, energies=energies, forces=None)
+
+    graph_dataset = MolecularGraphDataset(dataset, cutoff=3.0, dtype="float64")
+
+    graph = graph_dataset[0]
+    assert graph.positions.dtype == torch.float64

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,3 +31,33 @@ def test_run_baseline_training_creates_checkpoint(tmp_path):
     )
 
     assert (output_dir / "baseline.pt").exists()
+
+
+def test_run_baseline_training_least_squares(tmp_path):
+    dataset_path = tmp_path / "dataset_ls.npz"
+    atoms = np.array([
+        np.array([1, 6]),
+        np.array([6, 8]),
+        np.array([1, 8, 8]),
+    ], dtype=object)
+    coordinates = np.array([
+        np.zeros((2, 3), dtype=np.float32),
+        np.ones((2, 3), dtype=np.float32),
+        np.ones((3, 3), dtype=np.float32),
+    ], dtype=object)
+    energies = np.array([-1.0, -2.5, -3.0], dtype=np.float32)
+    np.savez(dataset_path, atoms=atoms, coordinates=coordinates, Etot=energies)
+
+    output_dir = tmp_path / "run_ls"
+
+    run_baseline_training(
+        dataset_path,
+        output_dir,
+        epochs=1,
+        batch_size=3,
+        learning_rate=1e-2,
+        validation_split=0.0,
+        solver="least_squares",
+    )
+
+    assert (output_dir / "baseline.pt").exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,8 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from deltamol.models.baseline import build_formula_vector
+from deltamol.models.gcn import GCNConfig, GCNPotential
+from deltamol.models.transformer import TransformerConfig, TransformerPotential
 
 
 def test_build_formula_vector_counts_species():
@@ -12,3 +14,35 @@ def test_build_formula_vector_counts_species():
     vector = build_formula_vector(atoms, species=species)
 
     assert torch.allclose(vector, torch.tensor([1.0, 1.0, 2.0]))
+
+
+def test_gcn_forward_pass_runs():
+    species = (1, 6, 8)
+    config = GCNConfig(species=species, hidden_dim=16, num_layers=2, predict_forces=True)
+    model = GCNPotential(config)
+    node_indices = torch.tensor([[1, 2, 3, 0], [3, 1, 0, 0]], dtype=torch.long)
+    positions = torch.randn(2, 4, 3)
+    adjacency = torch.eye(4).repeat(2, 1, 1)
+    mask = node_indices != 0
+
+    output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (2,)
+    assert output.forces is not None
+    assert output.forces.shape == (2, 4, 3)
+
+
+def test_transformer_forward_pass_runs():
+    species = (1, 6)
+    config = TransformerConfig(species=species, hidden_dim=8, num_layers=1, num_heads=2, predict_forces=True)
+    model = TransformerPotential(config)
+    node_indices = torch.tensor([[1, 2, 0], [2, 1, 1]], dtype=torch.long)
+    positions = torch.randn(2, 3, 3)
+    adjacency = torch.eye(3).repeat(2, 1, 1)
+    mask = node_indices != 0
+
+    output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (2,)
+    assert output.forces is not None
+    assert output.forces.shape == (2, 3, 3)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,103 @@
+import json
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from torch import nn
+from torch.utils.data import DataLoader
+
+from deltamol.training.pipeline import TensorDataset, Trainer, TrainingConfig, train_baseline
+
+
+def test_trainer_persists_history(tmp_path):
+    torch.manual_seed(0)
+    inputs = torch.randn(8, 3)
+    weights = torch.tensor([[1.0], [-2.0], [0.5]])
+    targets = inputs @ weights
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model = nn.Sequential(nn.Linear(3, 8), nn.ReLU(), nn.Linear(8, 1))
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=3,
+        learning_rate=1e-2,
+        batch_size=4,
+        log_every=1,
+    )
+    trainer = Trainer(model, config)
+
+    history = trainer.train(loader)
+
+    assert history == trainer.history
+    final_key = f"train/{config.epochs}"
+    assert final_key in history
+    history_path = tmp_path / "history.json"
+    assert history_path.exists()
+    with history_path.open("r", encoding="utf-8") as handle:
+        saved = json.load(handle)
+    assert saved == history
+
+
+def test_trainer_supports_optimizer_and_scheduler(tmp_path):
+    torch.manual_seed(1)
+    inputs = torch.randn(16, 4)
+    weights = torch.tensor([[0.5], [-1.0], [1.5], [0.25]])
+    targets = inputs @ weights
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model = nn.Sequential(nn.Linear(4, 8), nn.ReLU(), nn.Linear(8, 1))
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=2,
+        learning_rate=5e-3,
+        batch_size=4,
+        optimizer="adamw",
+        weight_decay=0.01,
+        scheduler="linear",
+        warmup_steps=2,
+        scheduler_total_steps=8,
+        min_lr_ratio=0.2,
+    )
+    trainer = Trainer(model, config)
+
+    trainer.train(loader)
+
+    assert trainer.scheduler is not None
+    final_lr = trainer.scheduler.get_last_lr()[0]
+    expected_lr = config.learning_rate * config.min_lr_ratio
+    assert pytest.approx(expected_lr, rel=1e-5) == final_lr
+    lr_keys = [key for key in trainer.history if key.startswith("lr/")]
+    assert lr_keys, "learning rate history should be recorded when scheduler is active"
+
+
+def test_train_baseline_least_squares(tmp_path):
+    torch.manual_seed(0)
+    formula_vectors = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+    true_weights = torch.tensor([1.5, -0.75, 0.25], dtype=torch.float32)
+    energies = formula_vectors @ true_weights
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        solver="least_squares",
+        validation_split=0.25,
+    )
+    trainer = train_baseline(
+        formula_vectors,
+        energies,
+        species=[1, 6, 8],
+        config=config,
+    )
+    learned = trainer.model.linear.weight.detach().cpu().squeeze(0)
+    assert torch.allclose(learned, true_weights, atol=1e-6)
+    assert pytest.approx(0.0, abs=1e-8) == trainer.history["train/1"]
+    if "val/1" in trainer.history:
+        assert pytest.approx(0.0, abs=1e-8) == trainer.history["val/1"]
+    history_path = tmp_path / "history.json"
+    assert history_path.exists()


### PR DESCRIPTION
## Summary
- add a solver option to baseline training so runs can choose an analytical least-squares fit instead of gradient descent
- implement the closed-form baseline fitter, persist its history, and surface the option on the CLI and docs
- cover the new solver path with unit tests for both the pipeline helper and CLI entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7fb441bc832fbcffeb7a653b9439