### PR TITLE
Add mixed precision training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,106 @@ The command will:
 1. Load the dataset and build atomic formula vectors.
 2. Train the linear baseline with mean squared error.
 3. Save the trained model checkpoint and configuration into the output folder.
+4. Persist both `baseline_best.pt` (best validation loss) and `baseline_last.pt`
+   (latest weights) so you can transfer the best model into potential training
+   while keeping a checkpoint that is ready to resume optimisation.
+
+When the baseline behaves like a simple linear regression, you can bypass
+iterative optimisation and recover the atomic energy coefficients with a single
+least-squares solve:
+
+```bash
+python -m deltamol.main train-baseline data.npz --solver least_squares
+```
+
+The same `solver` option can be stored inside a YAML configuration alongside
+other training overrides.
+
+Advanced options such as the optimizer family, scheduler, or device can be
+specified via a YAML file and passed to the command with `--config`. Any
+arguments provided on the CLI continue to override the values defined in the
+configuration file, so the most common tweaks remain one flag away:
+
+```yaml
+# baseline.yaml
+output_dir: runs/baseline-adamw
+optimizer: adamw
+weight_decay: 0.01
+scheduler: cosine
+warmup_steps: 500
+min_lr_ratio: 0.2
+device: cuda
+```
+
+```bash
+python -m deltamol.main train-baseline data.npz --config baseline.yaml --epochs 300
+```
+
+Add `--early-stopping-patience` and `--early-stopping-min-delta` to stop the
+run once the validation loss plateaus, and customise the checkpoint filenames
+with `--best-checkpoint-name` and `--last-checkpoint-name` if the defaults do
+not suit your workflow. The CLI mirrors these values inside the saved
+`config.yaml` so downstream tasks can discover which files contain the best and
+latest weights.
+
+When GPU memory is at a premium you can add `--mixed-precision` to enable
+automatic mixed precision. CUDA devices default to float16 autocasting while
+CPUs fall back to bfloat16; override the behaviour with `--precision-dtype` and
+use `--no-grad-scaler` to disable gradient scaling for edge cases that require
+manual control.
+
+### Potential training with configuration files
+
+The `train-potential` subcommand consumes a structured YAML file that describes
+dataset preprocessing, model architecture, and training parameters. Only the
+most important options such as the dataset path and output directory need to be
+specified on the CLI; all other values live alongside the experiment
+definition.
+
+```yaml
+# configs/potential.yaml
+dataset:
+  path: datasets/DFT_uniques.npz
+  cutoff: 6.0
+  dtype: float32
+model:
+  name: transformer
+  hidden_dim: 256
+  num_layers: 6
+  num_heads: 8
+  dropout: 0.1
+  predict_forces: true
+training:
+  output_dir: runs/potential-transformer
+  epochs: 80
+  batch_size: 16
+  learning_rate: 5.0e-4
+  optimizer: adamw
+  scheduler: cosine
+  warmup_steps: 1000
+  force_weight: 0.5
+  mixed_precision: true
+  autocast_dtype: float16
+baseline:
+  checkpoint: runs/baseline/baseline.pt
+  requires_grad: false
+```
+
+Launch the run with:
+
+```bash
+python -m deltamol.main train-potential --config configs/potential.yaml
+```
+
+The trainer will configure logging, build the requested model, run the
+experiment, and persist an `experiment.yaml` file in the output directory that
+captures the resolved dataset, model, and training parameters. In addition to
+the copied `potential.pt` convenience file, the run directory will contain
+`potential_best.pt` and `potential_last.pt` so you can evaluate the best model
+and resume from the final optimiser state with minimal effort. Mixed precision
+can be toggled directly in the YAML file via the `mixed_precision`,
+`autocast_dtype`, and `grad_scaler` fields or overridden on the CLI with
+`--mixed-precision`, `--precision-dtype`, and `--no-grad-scaler`.
 
 ### Descriptor caching
 

--- a/deltamol/cli/__init__.py
+++ b/deltamol/cli/__init__.py
@@ -2,16 +2,34 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import shutil
+from dataclasses import replace
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional, Sequence, Tuple
 
-from ..data.io import cache_descriptor_matrix, load_npz_dataset
+import torch
+
+from ..config.manager import load_config, save_config
+from ..data.io import MolecularDataset, cache_descriptor_matrix, load_npz_dataset
 from ..descriptors.acsf import build_acsf_descriptor
 from ..descriptors.fchl19 import build_fchl19_descriptor
 from ..descriptors.lmbtr import build_lmbtr_descriptor
 from ..descriptors.slatm import build_slatm_descriptor
 from ..descriptors.soap import build_soap_descriptor
 from ..main import run_baseline_training
+from ..models import (
+    GCNConfig,
+    GCNPotential,
+    LinearAtomicBaseline,
+    LinearBaselineConfig,
+    TransformerConfig,
+    TransformerPotential,
+)
+from ..training.configs import BaselineConfig, ModelConfig, PotentialExperimentConfig
+from ..training.datasets import MolecularGraphDataset
+from ..training.pipeline import TrainingConfig, train_potential_model
+from ..utils.logging import configure_logging
 
 _DESCRIPTOR_BUILDERS: Dict[str, Callable] = {
     "acsf": build_acsf_descriptor,
@@ -21,8 +39,65 @@ _DESCRIPTOR_BUILDERS: Dict[str, Callable] = {
     "fchl19": build_fchl19_descriptor,
 }
 
+LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_species(dataset: MolecularDataset, explicit: Optional[Sequence[int]]) -> Tuple[int, ...]:
+    if explicit:
+        return tuple(int(z) for z in explicit)
+    species = {int(z) for atoms in dataset.atoms for z in atoms}
+    return tuple(sorted(species))
+
+
+def _build_potential_model(model_cfg: ModelConfig, species: Sequence[int]):
+    species_tuple = tuple(int(z) for z in species)
+    name = model_cfg.name.lower()
+    if name == "gcn":
+        config = GCNConfig(
+            species=species_tuple,
+            hidden_dim=model_cfg.hidden_dim,
+            num_layers=model_cfg.num_layers,
+            dropout=model_cfg.dropout,
+            use_coordinate_features=model_cfg.use_coordinate_features,
+            predict_forces=model_cfg.predict_forces,
+        )
+        return GCNPotential(config)
+    if name in {"transformer", "transformer-potential"}:
+        config = TransformerConfig(
+            species=species_tuple,
+            hidden_dim=model_cfg.hidden_dim,
+            num_layers=model_cfg.num_layers,
+            num_heads=model_cfg.num_heads,
+            dropout=model_cfg.dropout,
+            ffn_dim=model_cfg.ffn_dim,
+            use_coordinate_features=model_cfg.use_coordinate_features,
+            predict_forces=model_cfg.predict_forces,
+        )
+        return TransformerPotential(config)
+    raise ValueError(f"Unsupported potential model '{model_cfg.name}'")
+
+
+def _load_baseline(
+    baseline_cfg: Optional[BaselineConfig], species: Sequence[int]
+) -> Tuple[Optional[LinearAtomicBaseline], bool]:
+    if baseline_cfg is None or baseline_cfg.checkpoint is None:
+        return None, True
+    resolved_species = tuple(
+        int(z) for z in (baseline_cfg.species if baseline_cfg.species else species)
+    )
+    model = LinearAtomicBaseline(LinearBaselineConfig(species=resolved_species))
+    checkpoint = torch.load(baseline_cfg.checkpoint, map_location="cpu")
+    if isinstance(checkpoint, dict) and "model_state" in checkpoint:
+        state_dict = checkpoint["model_state"]
+    else:
+        state_dict = checkpoint
+    model.load_state_dict(state_dict)
+    return model, bool(baseline_cfg.requires_grad)
+
 
 def _train_baseline(args: argparse.Namespace) -> None:
+    config = load_config(args.config, TrainingConfig) if args.config else None
+    grad_scaler = False if args.no_grad_scaler else None
     run_baseline_training(
         args.dataset,
         args.output,
@@ -30,7 +105,106 @@ def _train_baseline(args: argparse.Namespace) -> None:
         batch_size=args.batch_size,
         learning_rate=args.lr,
         validation_split=args.validation_split,
+        solver=args.solver,
+        early_stopping_patience=args.early_stopping_patience,
+        early_stopping_min_delta=args.early_stopping_min_delta,
+        best_checkpoint_name=args.best_checkpoint_name,
+        last_checkpoint_name=args.last_checkpoint_name,
+        mixed_precision=True if args.mixed_precision else None,
+        autocast_dtype=args.precision_dtype,
+        grad_scaler=grad_scaler,
+        config=config,
     )
+
+
+def _train_potential(args: argparse.Namespace) -> None:
+    experiment = load_config(args.config, PotentialExperimentConfig)
+    dataset_path = args.dataset or experiment.dataset.path
+    if dataset_path is None:
+        raise ValueError("A dataset path must be provided via the CLI or configuration file")
+    dataset_path = Path(dataset_path)
+    dataset = load_npz_dataset(dataset_path)
+    species = _resolve_species(dataset, experiment.dataset.species)
+    graph_dataset = MolecularGraphDataset(
+        dataset,
+        species=species,
+        cutoff=experiment.dataset.cutoff,
+        dtype=experiment.dataset.dtype,
+    )
+    training_cfg = experiment.training
+    overrides = {}
+    if args.output is not None:
+        overrides["output_dir"] = args.output
+    if args.epochs is not None:
+        overrides["epochs"] = args.epochs
+    if args.batch_size is not None:
+        overrides["batch_size"] = args.batch_size
+    if args.lr is not None:
+        overrides["learning_rate"] = args.lr
+    if args.validation_split is not None:
+        overrides["validation_split"] = args.validation_split
+    if args.mixed_precision:
+        overrides["mixed_precision"] = True
+    if args.precision_dtype is not None:
+        overrides["autocast_dtype"] = args.precision_dtype
+    if args.no_grad_scaler:
+        overrides["grad_scaler"] = False
+    if overrides:
+        if "output_dir" in overrides and not isinstance(overrides["output_dir"], Path):
+            overrides["output_dir"] = Path(overrides["output_dir"])
+        training_cfg = replace(training_cfg, **overrides)
+    elif not isinstance(training_cfg.output_dir, Path):
+        training_cfg = replace(training_cfg, output_dir=Path(training_cfg.output_dir))
+    if training_cfg.output_dir is None:
+        raise ValueError("Potential training configuration must define an output directory")
+    configure_logging(training_cfg.output_dir)
+    LOGGER.info("Training potential model using dataset at %s", dataset_path)
+    model = _build_potential_model(experiment.model, species)
+    baseline, baseline_trainable = _load_baseline(experiment.baseline, species)
+    if baseline is not None and experiment.baseline is not None:
+        LOGGER.info("Loaded baseline checkpoint from %s", experiment.baseline.checkpoint)
+        if not baseline_trainable:
+            LOGGER.info("Baseline parameters will remain frozen during potential training")
+    trainer = train_potential_model(
+        graph_dataset,
+        model,
+        config=training_cfg,
+        baseline=baseline,
+        baseline_requires_grad=baseline_trainable,
+    )
+    checkpoint_path = training_cfg.output_dir / "potential.pt"
+    best_path = trainer.best_checkpoint_path
+    last_path = trainer.last_checkpoint_path
+    if best_path is not None:
+        LOGGER.info("Best potential checkpoint saved to %s", best_path)
+    if last_path is not None and last_path != best_path:
+        LOGGER.info("Last potential checkpoint saved to %s", last_path)
+    alias_source = last_path or best_path
+    if alias_source is not None:
+        if Path(alias_source).resolve() != checkpoint_path.resolve():
+            shutil.copy2(alias_source, checkpoint_path)
+            LOGGER.info("Copied %s to %s", alias_source, checkpoint_path)
+        else:
+            LOGGER.info("Best potential checkpoint already stored at %s", checkpoint_path)
+    else:
+        trainer.save_checkpoint(checkpoint_path)
+        LOGGER.info("Saved potential checkpoint to %s", checkpoint_path)
+    resolved_dataset_cfg = replace(experiment.dataset, path=dataset_path, species=species)
+    resolved_model_cfg = replace(experiment.model)
+    resolved_baseline_cfg = (
+        replace(experiment.baseline, species=tuple(experiment.baseline.species or species))
+        if experiment.baseline is not None
+        else None
+    )
+    resolved_experiment = PotentialExperimentConfig(
+        training=training_cfg,
+        model=resolved_model_cfg,
+        dataset=resolved_dataset_cfg,
+        baseline=resolved_baseline_cfg,
+    )
+    config_path = training_cfg.output_dir / "experiment.yaml"
+    save_config(resolved_experiment, config_path)
+    LOGGER.info("Saved experiment configuration to %s", config_path)
 
 
 def _cache_descriptors(args: argparse.Namespace) -> None:
@@ -61,11 +235,113 @@ def build_parser() -> argparse.ArgumentParser:
     train_parser = subcommands.add_parser("train-baseline", help="Train the linear atomic baseline")
     train_parser.add_argument("dataset", type=Path, help="Path to the NPZ dataset")
     train_parser.add_argument("--output", type=Path, default=Path("runs/baseline"))
-    train_parser.add_argument("--epochs", type=int, default=200)
-    train_parser.add_argument("--batch-size", type=int, default=128)
-    train_parser.add_argument("--lr", type=float, default=1e-2)
-    train_parser.add_argument("--validation-split", type=float, default=0.1)
+    train_parser.add_argument("--config", type=Path, help="YAML file with training overrides")
+    train_parser.add_argument("--epochs", type=int, default=None, help="Number of epochs (default: 200)")
+    train_parser.add_argument("--batch-size", type=int, default=None, help="Batch size (default: 128)")
+    train_parser.add_argument("--lr", type=float, default=None, help="Learning rate (default: 1e-2)")
+    train_parser.add_argument(
+        "--mixed-precision",
+        action="store_true",
+        help="Enable automatic mixed precision during baseline optimisation",
+    )
+    train_parser.add_argument(
+        "--precision-dtype",
+        choices=["float16", "bfloat16", "fp16", "bf16"],
+        default=None,
+        help="Autocast dtype for mixed precision (default: float16 on CUDA, bfloat16 on CPU)",
+    )
+    train_parser.add_argument(
+        "--no-grad-scaler",
+        action="store_true",
+        help="Disable gradient scaling when mixed precision is enabled",
+    )
+    train_parser.add_argument(
+        "--validation-split",
+        type=float,
+        default=None,
+        help="Validation fraction (default: 0.1)",
+    )
+    train_parser.add_argument(
+        "--solver",
+        choices=["optimizer", "least_squares"],
+        default=None,
+        help="Solver for the baseline weights (default: optimizer)",
+    )
+    train_parser.add_argument(
+        "--early-stopping-patience",
+        type=int,
+        default=None,
+        help="Stop training after N epochs without validation improvement",
+    )
+    train_parser.add_argument(
+        "--early-stopping-min-delta",
+        type=float,
+        default=None,
+        help="Minimum change in validation loss to count as an improvement",
+    )
+    train_parser.add_argument(
+        "--best-checkpoint-name",
+        type=str,
+        default=None,
+        help="Filename for the best baseline checkpoint (default: baseline_best.pt)",
+    )
+    train_parser.add_argument(
+        "--last-checkpoint-name",
+        type=str,
+        default=None,
+        help="Filename for the most recent baseline checkpoint (default: baseline_last.pt)",
+    )
     train_parser.set_defaults(func=_train_baseline)
+
+    potential_parser = subcommands.add_parser(
+        "train-potential", help="Train a neural potential with configurable settings"
+    )
+    potential_parser.add_argument(
+        "dataset",
+        type=Path,
+        nargs="?",
+        help="Path to the NPZ dataset (overrides dataset.path in the config)",
+    )
+    potential_parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="YAML file describing dataset, model, and training parameters",
+    )
+    potential_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Override the output directory defined in the config",
+    )
+    potential_parser.add_argument("--epochs", type=int, default=None, help="Override epochs")
+    potential_parser.add_argument(
+        "--batch-size", type=int, default=None, help="Override batch size"
+    )
+    potential_parser.add_argument("--lr", type=float, default=None, help="Override learning rate")
+    potential_parser.add_argument(
+        "--validation-split",
+        type=float,
+        default=None,
+        help="Override validation split",
+    )
+    potential_parser.add_argument(
+        "--mixed-precision",
+        action="store_true",
+        help="Enable automatic mixed precision for potential training",
+    )
+    potential_parser.add_argument(
+        "--precision-dtype",
+        choices=["float16", "bfloat16", "fp16", "bf16"],
+        default=None,
+        help="Autocast dtype for mixed precision (default: float16 on CUDA, bfloat16 on CPU)",
+    )
+    potential_parser.add_argument(
+        "--no-grad-scaler",
+        action="store_true",
+        help="Disable gradient scaling during mixed precision runs",
+    )
+    potential_parser.set_defaults(func=_train_potential)
 
     descriptor_parser = subcommands.add_parser(
         "cache-descriptors", help="Generate and cache atomic descriptors"

--- a/deltamol/config/manager.py
+++ b/deltamol/config/manager.py
@@ -1,9 +1,10 @@
 """Configuration management helpers."""
 from __future__ import annotations
 
-from dataclasses import asdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, fields, is_dataclass
 from pathlib import Path
-from typing import Any, Type, TypeVar
+from typing import Any, Type, TypeVar, Union, get_args, get_origin
 
 try:
     import yaml
@@ -16,10 +17,22 @@ else:
 T = TypeVar("T")
 
 
+def _serialise_value(value: Any) -> Any:
+    """Convert dataclass values to YAML friendly structures."""
+
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {key: _serialise_value(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_serialise_value(item) for item in value]
+    return value
+
+
 def save_config(config: Any, path: Path) -> None:
     if yaml is None:
         raise ImportError("pyyaml is required to save configs") from _IMPORT_ERROR
-    data = asdict(config)
+    data = _serialise_value(asdict(config) if is_dataclass(config) else config)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=False))
 
@@ -28,4 +41,58 @@ def load_config(path: Path, cls: Type[T]) -> T:
     if yaml is None:
         raise ImportError("pyyaml is required to load configs") from _IMPORT_ERROR
     data = yaml.safe_load(path.read_text())
+    if is_dataclass(cls):
+        if not isinstance(data, Mapping):
+            raise TypeError("Configuration file must contain a mapping at the top level")
+        return _build_dataclass(cls, data)
     return cls(**data)
+
+
+def _build_dataclass(cls: Type[T], data: Mapping[str, Any]) -> T:
+    """Instantiate ``cls`` from the mapping ``data``."""
+
+    kwargs: dict[str, Any] = {}
+    for field in fields(cls):
+        if field.name not in data:
+            continue
+        kwargs[field.name] = _coerce_value(field.type, data[field.name])
+    return cls(**kwargs)
+
+
+def _coerce_value(annotation: Any, value: Any) -> Any:
+    """Convert ``value`` so it matches the provided type annotation."""
+
+    if value is None:
+        return None
+    origin = get_origin(annotation)
+    if origin is None:
+        if annotation is Path:
+            return Path(value)
+        if is_dataclass(annotation) and isinstance(value, Mapping):
+            return _build_dataclass(annotation, value)
+        return value
+    args = get_args(annotation)
+    if origin in (list, Sequence):
+        inner = args[0] if args else Any
+        return [_coerce_value(inner, item) for item in value]
+    if origin is tuple:
+        if len(args) == 2 and args[1] is Ellipsis:
+            inner = args[0]
+            return tuple(_coerce_value(inner, item) for item in value)
+        return tuple(_coerce_value(arg, item) for arg, item in zip(args, value))
+    if origin in (dict, Mapping):
+        key_type, val_type = args if len(args) == 2 else (Any, Any)
+        return {
+            _coerce_value(key_type, key): _coerce_value(val_type, item)
+            for key, item in value.items()
+        }
+    if origin is Union:
+        for option in args:
+            if option is type(None):  # noqa: E721 - Optional detection
+                continue
+            try:
+                return _coerce_value(option, value)
+            except Exception:
+                continue
+        return value
+    return value

--- a/deltamol/main.py
+++ b/deltamol/main.py
@@ -1,8 +1,11 @@
 """High level entry points for DeltaMol."""
 from __future__ import annotations
 
+import logging
+import shutil
+from dataclasses import replace
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 import torch
 
@@ -10,38 +13,131 @@ from .config.manager import save_config
 from .data.io import load_npz_dataset
 from .models.baseline import build_formula_vector
 from .training.pipeline import TrainingConfig, train_baseline
+from .utils.logging import configure_logging
+
+LOGGER = logging.getLogger(__name__)
 
 
 def run_baseline_training(
     dataset_path: Path,
     output_dir: Path,
     *,
-    epochs: int = 200,
-    batch_size: int = 128,
-    learning_rate: float = 1e-2,
-    validation_split: float = 0.1,
+    epochs: Optional[int] = None,
+    batch_size: Optional[int] = None,
+    learning_rate: Optional[float] = None,
+    validation_split: Optional[float] = None,
+    solver: Optional[str] = None,
+    early_stopping_patience: Optional[int] = None,
+    early_stopping_min_delta: Optional[float] = None,
+    best_checkpoint_name: Optional[str] = None,
+    last_checkpoint_name: Optional[str] = None,
+    mixed_precision: Optional[bool] = None,
+    autocast_dtype: Optional[str] = None,
+    grad_scaler: Optional[bool] = None,
+    config: TrainingConfig | None = None,
 ) -> None:
     """Train the linear atomic baseline on a dataset."""
 
+    configure_logging(output_dir)
     dataset = load_npz_dataset(dataset_path)
     species = sorted({int(z) for atoms in dataset.atoms for z in atoms})
+    LOGGER.info(
+        "Starting baseline training on %d molecules with %d species",
+        len(dataset.energies),
+        len(species),
+    )
     formula_vectors = torch.stack(
         [build_formula_vector(atoms, species=species) for atoms in dataset.atoms]
     )
     energies = torch.tensor(dataset.energies, dtype=torch.float32)
-    config = TrainingConfig(
-        output_dir=output_dir,
-        epochs=epochs,
-        learning_rate=learning_rate,
-        batch_size=batch_size,
-        validation_split=validation_split,
-    )
+    override_kwargs = {}
+    if mixed_precision is not None:
+        override_kwargs["mixed_precision"] = mixed_precision
+    if autocast_dtype is not None:
+        override_kwargs["autocast_dtype"] = autocast_dtype
+    if grad_scaler is not None:
+        override_kwargs["grad_scaler"] = grad_scaler
+    if config is None:
+        config = TrainingConfig(
+            output_dir=output_dir,
+            epochs=epochs if epochs is not None else 200,
+            learning_rate=learning_rate if learning_rate is not None else 1e-2,
+            batch_size=batch_size if batch_size is not None else 128,
+            validation_split=validation_split if validation_split is not None else 0.1,
+            solver=solver if solver is not None else "optimizer",
+            early_stopping_patience=(
+                early_stopping_patience if early_stopping_patience is not None else 0
+            ),
+            early_stopping_min_delta=(
+                early_stopping_min_delta if early_stopping_min_delta is not None else 0.0
+            ),
+            best_checkpoint_name=(best_checkpoint_name or "baseline_best.pt"),
+            last_checkpoint_name=(last_checkpoint_name or "baseline_last.pt"),
+            **override_kwargs,
+        )
+    else:
+        config = replace(
+            config,
+            output_dir=output_dir,
+            epochs=epochs if epochs is not None else config.epochs,
+            learning_rate=learning_rate if learning_rate is not None else config.learning_rate,
+            batch_size=batch_size if batch_size is not None else config.batch_size,
+            validation_split=(
+                validation_split
+                if validation_split is not None
+                else config.validation_split
+            ),
+            solver=solver if solver is not None else config.solver,
+            early_stopping_patience=(
+                early_stopping_patience
+                if early_stopping_patience is not None
+                else config.early_stopping_patience
+            ),
+            early_stopping_min_delta=(
+                early_stopping_min_delta
+                if early_stopping_min_delta is not None
+                else config.early_stopping_min_delta
+            ),
+            best_checkpoint_name=(
+                best_checkpoint_name
+                if best_checkpoint_name is not None
+                else config.best_checkpoint_name
+            ),
+            last_checkpoint_name=(
+                last_checkpoint_name
+                if last_checkpoint_name is not None
+                else config.last_checkpoint_name
+            ),
+            **override_kwargs,
+        )
+        if not config.best_checkpoint_name:
+            config = replace(config, best_checkpoint_name="baseline_best.pt")
+        if not config.last_checkpoint_name:
+            config = replace(config, last_checkpoint_name="baseline_last.pt")
     trainer = train_baseline(formula_vectors, energies, species=species, config=config)
-    trainer.save_checkpoint(output_dir / "baseline.pt")
+    best_path = trainer.best_checkpoint_path
+    last_path = trainer.last_checkpoint_path
+    if best_path is not None:
+        LOGGER.info("Best baseline checkpoint saved to %s", best_path)
+    if last_path is not None and last_path != best_path:
+        LOGGER.info("Last baseline checkpoint saved to %s", last_path)
+    alias_source = best_path or last_path
+    checkpoint_path = output_dir / "baseline.pt"
+    if alias_source is not None:
+        if Path(alias_source).resolve() != checkpoint_path.resolve():
+            shutil.copy2(alias_source, checkpoint_path)
+            LOGGER.info("Copied %s to %s", alias_source, checkpoint_path)
+        else:
+            LOGGER.info("Best baseline checkpoint already stored at %s", checkpoint_path)
+    else:
+        trainer.save_checkpoint(checkpoint_path)
+        LOGGER.info("Saved baseline checkpoint to %s", checkpoint_path)
     try:
-        save_config(config, output_dir / "config.yaml")
+        config_path = output_dir / "config.yaml"
+        save_config(config, config_path)
+        LOGGER.info("Saved training configuration to %s", config_path)
     except ImportError as exc:
-        print(f"Skipping config serialization: {exc}")
+        LOGGER.warning("Skipping config serialization: %s", exc)
 
 
 def main(argv: Iterable[str] | None = None) -> None:
@@ -53,3 +149,7 @@ def main(argv: Iterable[str] | None = None) -> None:
 
 
 __all__ = ["main", "run_baseline_training"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
+    main()

--- a/deltamol/models/__init__.py
+++ b/deltamol/models/__init__.py
@@ -1,11 +1,19 @@
 """Model definitions for DeltaMol."""
 from .baseline import LinearAtomicBaseline, LinearBaselineConfig, build_formula_vector
+from .gcn import GCNConfig, GCNPotential
 from .graph import EnergyCorrectionNetwork, GraphModelConfig
+from .potential import PotentialOutput
+from .transformer import TransformerConfig, TransformerPotential
 
 __all__ = [
     "LinearAtomicBaseline",
     "LinearBaselineConfig",
     "build_formula_vector",
+    "GCNConfig",
+    "GCNPotential",
     "EnergyCorrectionNetwork",
     "GraphModelConfig",
+    "PotentialOutput",
+    "TransformerConfig",
+    "TransformerPotential",
 ]

--- a/deltamol/models/gcn.py
+++ b/deltamol/models/gcn.py
@@ -1,0 +1,110 @@
+"""Graph convolutional potential models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+@dataclass
+class GCNConfig:
+    """Configuration for :class:`GCNPotential`."""
+
+    species: Tuple[int, ...]
+    hidden_dim: int = 128
+    num_layers: int = 3
+    dropout: float = 0.1
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+
+
+class GCNLayer(nn.Module):
+    """Lightweight GCN layer operating on dense adjacency matrices."""
+
+    def __init__(self, in_dim: int, out_dim: int, *, dropout: float):
+        super().__init__()
+        self.linear = nn.Linear(in_dim, out_dim)
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, adjacency: torch.Tensor, features: torch.Tensor) -> torch.Tensor:
+        h = torch.matmul(adjacency, features)
+        h = self.linear(h)
+        h = self.activation(h)
+        return self.dropout(h)
+
+
+class GCNPotential(nn.Module):
+    """Predict molecular energies (and optionally forces) with a GCN."""
+
+    def __init__(self, config: GCNConfig):
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+        self.embedding = nn.Embedding(num_species + 1, config.hidden_dim, padding_idx=0)
+        if config.use_coordinate_features:
+            self.coordinate_mlp = nn.Sequential(
+                nn.Linear(3, config.hidden_dim),
+                nn.ReLU(),
+                nn.Linear(config.hidden_dim, config.hidden_dim),
+            )
+        else:
+            self.coordinate_mlp = None
+        layers = []
+        for _ in range(config.num_layers):
+            layers.append(GCNLayer(config.hidden_dim, config.hidden_dim, dropout=config.dropout))
+        self.layers = nn.ModuleList(layers)
+        self.energy_head = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+        if config.predict_forces:
+            self.force_head = nn.Linear(config.hidden_dim, 3)
+        else:
+            self.force_head = None
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask = mask.bool()
+        mask_float = mask.float()
+        adj = self._normalize_adjacency(adjacency, mask_float)
+        h = self.embedding(node_indices)
+        if self.coordinate_mlp is not None:
+            h = h + self.coordinate_mlp(positions)
+        for layer in self.layers:
+            h = layer(adj, h)
+        pooled = self._masked_mean(h, mask_float)
+        energy = self.energy_head(pooled).squeeze(-1)
+        forces = None
+        if self.force_head is not None:
+            forces = self.force_head(h) * mask_float.unsqueeze(-1)
+        return PotentialOutput(energy=energy, forces=forces)
+
+    def _normalize_adjacency(self, adjacency: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        eye = torch.eye(adjacency.size(-1), device=adjacency.device).unsqueeze(0)
+        adjacency = adjacency * mask.unsqueeze(1) * mask.unsqueeze(2)
+        adjacency = adjacency + eye * mask.unsqueeze(-1)
+        degree = adjacency.sum(dim=-1)
+        inv_sqrt_degree = degree.clamp(min=1e-6).pow(-0.5)
+        inv_sqrt_degree = inv_sqrt_degree * mask
+        norm = adjacency * inv_sqrt_degree.unsqueeze(-1) * inv_sqrt_degree.unsqueeze(-2)
+        return norm
+
+    def _masked_mean(self, tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        masked = tensor * mask.unsqueeze(-1)
+        denom = mask.sum(dim=1, keepdim=True).clamp(min=1.0)
+        return masked.sum(dim=1) / denom
+
+
+__all__ = ["GCNConfig", "GCNPotential"]
+

--- a/deltamol/models/potential.py
+++ b/deltamol/models/potential.py
@@ -1,0 +1,18 @@
+"""Shared utilities for potential energy models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class PotentialOutput:
+    """Container holding predictions from a potential model."""
+
+    energy: torch.Tensor
+    forces: torch.Tensor | None = None
+
+
+__all__ = ["PotentialOutput"]
+

--- a/deltamol/models/transformer.py
+++ b/deltamol/models/transformer.py
@@ -1,0 +1,90 @@
+"""Transformer-based potential energy model."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+@dataclass
+class TransformerConfig:
+    """Configuration options for :class:`TransformerPotential`."""
+
+    species: Tuple[int, ...]
+    hidden_dim: int = 128
+    num_layers: int = 4
+    num_heads: int = 8
+    dropout: float = 0.1
+    ffn_dim: int = 256
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+
+
+class TransformerPotential(nn.Module):
+    """Encode atom-wise features with a Transformer encoder."""
+
+    def __init__(self, config: TransformerConfig):
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+        self.embedding = nn.Embedding(num_species + 1, config.hidden_dim, padding_idx=0)
+        if config.use_coordinate_features:
+            self.coordinate_mlp = nn.Sequential(
+                nn.Linear(3, config.hidden_dim),
+                nn.ReLU(),
+                nn.Linear(config.hidden_dim, config.hidden_dim),
+            )
+        else:
+            self.coordinate_mlp = None
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.hidden_dim,
+            nhead=config.num_heads,
+            dim_feedforward=config.ffn_dim,
+            dropout=config.dropout,
+            batch_first=True,
+            activation="gelu",
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=config.num_layers)
+        self.energy_head = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.ReLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+        if config.predict_forces:
+            self.force_head = nn.Linear(config.hidden_dim, 3)
+        else:
+            self.force_head = None
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor,  # kept for API parity, not used directly
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask = mask.bool()
+        mask_float = mask.float()
+        x = self.embedding(node_indices)
+        if self.coordinate_mlp is not None:
+            x = x + self.coordinate_mlp(positions)
+        encoded = self.encoder(x, src_key_padding_mask=~mask)
+        pooled = self._masked_mean(encoded, mask_float)
+        energy = self.energy_head(pooled).squeeze(-1)
+        forces = None
+        if self.force_head is not None:
+            forces = self.force_head(encoded) * mask_float.unsqueeze(-1)
+        return PotentialOutput(energy=energy, forces=forces)
+
+    def _masked_mean(self, tensor: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        masked = tensor * mask.unsqueeze(-1)
+        denom = mask.sum(dim=1, keepdim=True).clamp(min=1.0)
+        return masked.sum(dim=1) / denom
+
+
+__all__ = ["TransformerConfig", "TransformerPotential"]
+

--- a/deltamol/training/__init__.py
+++ b/deltamol/training/__init__.py
@@ -1,9 +1,29 @@
 """Training utilities for DeltaMol."""
-from .pipeline import TensorDataset, Trainer, TrainingConfig, train_baseline
+from .configs import BaselineConfig, DatasetConfig, ModelConfig, PotentialExperimentConfig
+from .datasets import MolecularGraph, MolecularGraphDataset, collate_graphs
+from .pipeline import (
+    PotentialTrainer,
+    PotentialTrainingConfig,
+    TensorDataset,
+    Trainer,
+    TrainingConfig,
+    train_baseline,
+    train_potential_model,
+)
 
 __all__ = [
+    "BaselineConfig",
+    "DatasetConfig",
+    "ModelConfig",
+    "MolecularGraph",
+    "MolecularGraphDataset",
+    "PotentialTrainer",
+    "PotentialTrainingConfig",
+    "PotentialExperimentConfig",
     "TensorDataset",
     "Trainer",
     "TrainingConfig",
+    "collate_graphs",
     "train_baseline",
+    "train_potential_model",
 ]

--- a/deltamol/training/configs.py
+++ b/deltamol/training/configs.py
@@ -1,0 +1,60 @@
+"""Dataclasses describing configurable training components."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .pipeline import PotentialTrainingConfig
+
+
+@dataclass
+class DatasetConfig:
+    """Options that control dataset preparation for potential training."""
+
+    path: Optional[Path] = None
+    cutoff: float = 5.0
+    dtype: str = "float32"
+    species: Optional[Tuple[int, ...]] = None
+
+
+@dataclass
+class BaselineConfig:
+    """Configuration describing a precomputed linear baseline model."""
+
+    checkpoint: Optional[Path] = None
+    species: Optional[Tuple[int, ...]] = None
+    requires_grad: bool = True
+
+
+@dataclass
+class ModelConfig:
+    """Lightweight description of the neural potential to construct."""
+
+    name: str = "gcn"
+    hidden_dim: int = 128
+    num_layers: int = 3
+    dropout: float = 0.1
+    use_coordinate_features: bool = True
+    predict_forces: bool = False
+    num_heads: int = 8
+    ffn_dim: int = 256
+
+
+@dataclass
+class PotentialExperimentConfig:
+    """Bundle dataset, model, and training configuration together."""
+
+    training: PotentialTrainingConfig
+    model: ModelConfig
+    dataset: DatasetConfig = field(default_factory=DatasetConfig)
+    baseline: Optional[BaselineConfig] = None
+
+
+__all__ = [
+    "BaselineConfig",
+    "DatasetConfig",
+    "ModelConfig",
+    "PotentialExperimentConfig",
+]
+

--- a/deltamol/training/datasets.py
+++ b/deltamol/training/datasets.py
@@ -1,0 +1,140 @@
+"""Dataset helpers for potential energy training."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from ..data.io import MolecularDataset
+from ..models.baseline import build_formula_vector
+
+
+@dataclass
+class MolecularGraph:
+    """Lightweight container describing a single molecular geometry."""
+
+    node_indices: torch.Tensor
+    positions: torch.Tensor
+    adjacency: torch.Tensor
+    energy: torch.Tensor
+    formula_vector: torch.Tensor
+    forces: Optional[torch.Tensor] = None
+
+
+class MolecularGraphDataset(Dataset):
+    """Construct dense graph representations from :class:`MolecularDataset`."""
+
+    def __init__(
+        self,
+        dataset: MolecularDataset,
+        *,
+        species: Optional[Sequence[int]] = None,
+        cutoff: float = 5.0,
+        dtype: Union[torch.dtype, str] = torch.float32,
+    ) -> None:
+        self.cutoff = cutoff
+        if species is None:
+            unique_species = {int(z) for atoms in dataset.atoms for z in atoms}
+            species = tuple(sorted(unique_species))
+        self.species: Tuple[int, ...] = tuple(int(z) for z in species)
+        if isinstance(dtype, str):
+            try:
+                dtype = getattr(torch, dtype)
+            except AttributeError as exc:
+                raise ValueError(f"Unknown dtype string '{dtype}'") from exc
+            if not isinstance(dtype, torch.dtype):
+                raise ValueError(f"Resolved dtype '{dtype}' is not a torch.dtype")
+        self.dtype = dtype
+        self.index_map: Dict[int, int] = {z: i + 1 for i, z in enumerate(self.species)}
+        self.has_forces = dataset.forces is not None
+        self.graphs: List[MolecularGraph] = []
+        for i, atoms in enumerate(dataset.atoms):
+            coordinates = dataset.coordinates[i]
+            energy = dataset.energies[i] if dataset.energies is not None else 0.0
+            graph = self._build_graph(atoms, coordinates, energy, dataset.forces[i] if self.has_forces else None)
+            self.graphs.append(graph)
+
+    def _atoms_to_indices(self, atoms: Iterable[int]) -> torch.Tensor:
+        indices = [self.index_map[int(z)] for z in atoms]
+        return torch.tensor(indices, dtype=torch.long)
+
+    def _build_adjacency(self, positions: torch.Tensor) -> torch.Tensor:
+        distances = torch.cdist(positions, positions)
+        adjacency = (distances < self.cutoff).float()
+        adjacency.fill_diagonal_(0.0)
+        return adjacency
+
+    def _build_graph(
+        self,
+        atoms: np.ndarray,
+        coordinates: np.ndarray,
+        energy: float,
+        forces: Optional[np.ndarray],
+    ) -> MolecularGraph:
+        node_indices = self._atoms_to_indices(atoms)
+        positions_array = np.asarray(coordinates, dtype=float)
+        positions = torch.tensor(positions_array, dtype=self.dtype)
+        adjacency = self._build_adjacency(positions)
+        energy_tensor = torch.tensor(float(energy), dtype=self.dtype)
+        formula_vector = build_formula_vector(atoms, species=self.species).to(self.dtype)
+        forces_tensor = None
+        if forces is not None:
+            forces_tensor = torch.tensor(np.asarray(forces, dtype=float), dtype=self.dtype)
+        return MolecularGraph(
+            node_indices=node_indices,
+            positions=positions,
+            adjacency=adjacency,
+            energy=energy_tensor,
+            formula_vector=formula_vector,
+            forces=forces_tensor,
+        )
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.graphs)
+
+    def __getitem__(self, index: int) -> MolecularGraph:
+        return self.graphs[index]
+
+
+def collate_graphs(batch: Sequence[MolecularGraph]) -> Dict[str, torch.Tensor]:
+    """Pad a batch of :class:`MolecularGraph` objects into dense tensors."""
+
+    batch_size = len(batch)
+    max_nodes = max(graph.node_indices.numel() for graph in batch)
+    feature_dim = batch[0].formula_vector.numel()
+    node_indices = torch.zeros(batch_size, max_nodes, dtype=torch.long)
+    positions = torch.zeros(batch_size, max_nodes, 3, dtype=batch[0].positions.dtype)
+    adjacency = torch.zeros(batch_size, max_nodes, max_nodes, dtype=batch[0].adjacency.dtype)
+    mask = torch.zeros(batch_size, max_nodes, dtype=torch.bool)
+    formula_vectors = torch.zeros(batch_size, feature_dim, dtype=batch[0].formula_vector.dtype)
+    energies = torch.zeros(batch_size, dtype=batch[0].energy.dtype)
+    has_forces = batch[0].forces is not None
+    forces = torch.zeros(batch_size, max_nodes, 3, dtype=batch[0].positions.dtype) if has_forces else None
+    for i, graph in enumerate(batch):
+        n = graph.node_indices.numel()
+        node_indices[i, :n] = graph.node_indices
+        positions[i, :n] = graph.positions
+        adjacency[i, :n, :n] = graph.adjacency
+        mask[i, :n] = True
+        formula_vectors[i] = graph.formula_vector
+        energies[i] = graph.energy
+        if has_forces and graph.forces is not None:
+            forces[i, :n] = graph.forces
+    batch_dict = {
+        "node_indices": node_indices,
+        "positions": positions,
+        "adjacency": adjacency,
+        "mask": mask,
+        "energies": energies,
+        "formula_vectors": formula_vectors,
+    }
+    if has_forces:
+        batch_dict["forces"] = forces
+    return batch_dict
+
+
+__all__ = ["MolecularGraph", "MolecularGraphDataset", "collate_graphs"]
+

--- a/deltamol/training/pipeline.py
+++ b/deltamol/training/pipeline.py
@@ -1,15 +1,251 @@
 """High level training orchestration utilities."""
 from __future__ import annotations
 
+import json
+import logging
+import math
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Tuple
 
 import torch
 from torch import nn
+from torch.optim import Optimizer
 from torch.utils.data import DataLoader, Dataset, random_split
 
 from ..models.baseline import LinearAtomicBaseline, LinearBaselineConfig
+from ..models.potential import PotentialOutput
+from .datasets import MolecularGraphDataset, collate_graphs
+
+LOGGER = logging.getLogger(__name__)
+
+
+try:  # pragma: no cover - torch<2.0 fallback
+    from torch.amp import GradScaler as _GradScalerBase
+except ImportError:  # pragma: no cover - legacy path
+    from torch.cuda.amp import GradScaler as _GradScalerBase  # type: ignore[attr-defined]
+
+
+def _make_grad_scaler(enabled: bool) -> _GradScalerBase:
+    """Instantiate a :class:`GradScaler` handling old and new signatures."""
+
+    try:
+        return _GradScalerBase(device_type="cuda", enabled=enabled)  # type: ignore[call-arg]
+    except TypeError:  # pragma: no cover - torch<2.0 signature
+        return _GradScalerBase(enabled=enabled)
+
+
+def _emit_info(message: str) -> None:
+    """Emit an informational message via logging with stdout fallback."""
+
+    LOGGER.info(message)
+    if not (LOGGER.hasHandlers() and LOGGER.isEnabledFor(logging.INFO)):
+        print(message)
+
+
+def _save_history(output_dir: Path, history: Dict[str, float]) -> Path:
+    """Persist a training history dictionary to ``history.json``."""
+
+    history_path = output_dir / "history.json"
+    with history_path.open("w", encoding="utf-8") as handle:
+        json.dump(history, handle, indent=2)
+    _emit_info(f"Saved training history to {history_path}")
+    return history_path
+
+
+def _resolve_autocast_settings(
+    device: torch.device, config: "TrainingConfig"
+) -> Tuple[bool, Optional[str], Optional[torch.dtype], bool]:
+    """Determine whether autocast should be enabled for the trainer."""
+
+    if not getattr(config, "mixed_precision", False):
+        return False, None, None, False
+    device_type = device.type
+    dtype_name = str(getattr(config, "autocast_dtype", None) or "float16").lower()
+    if device_type == "cuda":
+        mapping = {
+            "float16": torch.float16,
+            "fp16": torch.float16,
+            "half": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "bf16": torch.bfloat16,
+        }
+        if dtype_name not in mapping:
+            raise ValueError(f"Unsupported autocast dtype '{dtype_name}' for CUDA mixed precision")
+        dtype = mapping[dtype_name]
+        scaler_enabled = bool(getattr(config, "grad_scaler", True)) and dtype == torch.float16
+        return True, device_type, dtype, scaler_enabled
+    if device_type == "cpu":
+        mapping = {
+            "bfloat16": torch.bfloat16,
+            "bf16": torch.bfloat16,
+            "float16": torch.bfloat16,
+            "fp16": torch.bfloat16,
+            "half": torch.bfloat16,
+        }
+        dtype = mapping.get(dtype_name)
+        if dtype is None:
+            raise ValueError(f"Unsupported autocast dtype '{dtype_name}' for CPU mixed precision")
+        if dtype_name not in {"bfloat16", "bf16"}:
+            _emit_info(
+                "CPU mixed precision only supports bfloat16; falling back to bfloat16 autocast."
+            )
+        return True, device_type, torch.bfloat16, False
+    _emit_info(
+        "Mixed precision requested on device type '%s', but autocast is not supported; disabling mixed precision."
+        % device_type
+    )
+    return False, None, None, False
+
+
+def _autocast_context(
+    enabled: bool, device_type: Optional[str], dtype: Optional[torch.dtype]
+):
+    if not enabled or device_type is None or dtype is None:
+        return nullcontext()
+    return torch.autocast(device_type=device_type, dtype=dtype)
+
+
+class WarmupDecayScheduler:
+    """Learning rate scheduler with warmup and configurable decay."""
+
+    def __init__(
+        self,
+        optimizer: Optimizer,
+        *,
+        warmup_steps: int,
+        total_steps: int,
+        strategy: str,
+        min_lr_ratio: float,
+        gamma: float,
+        step_size: int,
+    ) -> None:
+        self.optimizer = optimizer
+        self.strategy = strategy
+        self.warmup_steps = max(int(warmup_steps), 0)
+        inferred_total = max(int(total_steps), 1)
+        self.total_steps = max(inferred_total, self.warmup_steps + 1)
+        self.min_lr_ratio = max(float(min_lr_ratio), 0.0)
+        self.gamma = float(gamma)
+        self.step_size = max(int(step_size), 1)
+        self.base_lrs = [group["lr"] for group in optimizer.param_groups]
+        self.current_step = 0
+        self.last_lrs = list(self.base_lrs)
+        self._apply_lrs()
+
+    def state_dict(self) -> Dict[str, object]:
+        return {
+            "current_step": self.current_step,
+            "last_lrs": list(self.last_lrs),
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, object]) -> None:
+        self.current_step = int(state_dict.get("current_step", 0))
+        self._apply_lrs()
+
+    def step(self) -> None:
+        if self.current_step < self.total_steps - 1:
+            self.current_step += 1
+        self._apply_lrs()
+
+    def _apply_lrs(self) -> None:
+        factor = self._compute_factor(self.current_step)
+        self.last_lrs = []
+        for base_lr, group in zip(self.base_lrs, self.optimizer.param_groups):
+            new_lr = base_lr * factor
+            group["lr"] = new_lr
+            self.last_lrs.append(new_lr)
+
+    def _compute_factor(self, step: int) -> float:
+        if self.total_steps <= 1:
+            return 1.0
+        if step < self.warmup_steps:
+            return (step + 1) / max(1, self.warmup_steps)
+        decay_steps = self.total_steps - self.warmup_steps
+        if decay_steps <= 1:
+            return 1.0
+        progress = (step - self.warmup_steps) / max(decay_steps - 1, 1)
+        progress = min(max(progress, 0.0), 1.0)
+        if self.strategy == "linear":
+            value = 1.0 - (1.0 - self.min_lr_ratio) * progress
+        elif self.strategy == "cosine":
+            value = self.min_lr_ratio + (1.0 - self.min_lr_ratio) * 0.5 * (
+                1.0 + math.cos(math.pi * progress)
+            )
+        elif self.strategy == "exponential":
+            exponent = max(step - self.warmup_steps, 0)
+            value = self.gamma**exponent
+        elif self.strategy == "step":
+            exponent = max(step - self.warmup_steps, 0) // self.step_size
+            value = self.gamma**exponent
+        elif self.strategy == "constant":
+            value = 1.0
+        else:  # pragma: no cover - guarded by validation
+            raise ValueError(f"Unknown scheduler strategy: {self.strategy}")
+        return max(value, self.min_lr_ratio)
+
+    def get_last_lr(self) -> Sequence[float]:
+        return list(self.last_lrs)
+
+
+def _build_optimizer(parameters, config: TrainingConfig) -> Optimizer:
+    name = config.optimizer.lower()
+    if name == "adam":
+        return torch.optim.Adam(
+            parameters,
+            lr=config.learning_rate,
+            betas=(config.beta1, config.beta2),
+            eps=config.eps,
+            weight_decay=config.weight_decay,
+            amsgrad=config.amsgrad,
+        )
+    if name == "adamw":
+        return torch.optim.AdamW(
+            parameters,
+            lr=config.learning_rate,
+            betas=(config.beta1, config.beta2),
+            eps=config.eps,
+            weight_decay=config.weight_decay,
+            amsgrad=config.amsgrad,
+        )
+    if name == "sgd":
+        return torch.optim.SGD(
+            parameters,
+            lr=config.learning_rate,
+            momentum=config.momentum,
+            weight_decay=config.weight_decay,
+            nesterov=config.nesterov,
+        )
+    raise ValueError(f"Unsupported optimizer '{config.optimizer}'")
+
+
+def _maybe_build_scheduler(
+    optimizer: Optimizer, config: TrainingConfig, steps_per_epoch: Optional[int]
+) -> Optional[WarmupDecayScheduler]:
+    strategy = (config.scheduler or "").lower()
+    if not strategy:
+        return None
+    supported = {"linear", "cosine", "exponential", "step", "constant"}
+    if strategy not in supported:
+        raise ValueError(f"Unsupported scheduler '{config.scheduler}'")
+    if config.scheduler_total_steps is not None:
+        total_steps = int(config.scheduler_total_steps)
+    elif steps_per_epoch is not None:
+        total_steps = steps_per_epoch * max(config.epochs, 1)
+    else:
+        return None
+    if total_steps <= 0:
+        return None
+    return WarmupDecayScheduler(
+        optimizer,
+        warmup_steps=config.warmup_steps,
+        total_steps=total_steps,
+        strategy=strategy,
+        min_lr_ratio=config.min_lr_ratio,
+        gamma=config.scheduler_gamma,
+        step_size=config.scheduler_step_size,
+    )
 
 
 @dataclass
@@ -20,7 +256,29 @@ class TrainingConfig:
     batch_size: int = 32
     log_every: int = 10
     device: str = "auto"
+    mixed_precision: bool = False
+    autocast_dtype: str = "float16"
+    grad_scaler: bool = True
     validation_split: float = 0.1
+    optimizer: str = "adam"
+    weight_decay: float = 0.0
+    beta1: float = 0.9
+    beta2: float = 0.999
+    eps: float = 1e-8
+    amsgrad: bool = False
+    momentum: float = 0.9
+    nesterov: bool = False
+    solver: str = "optimizer"
+    scheduler: Optional[str] = None
+    warmup_steps: int = 0
+    min_lr_ratio: float = 0.0
+    scheduler_gamma: float = 0.1
+    scheduler_step_size: int = 1000
+    scheduler_total_steps: Optional[int] = None
+    early_stopping_patience: int = 0
+    early_stopping_min_delta: float = 0.0
+    best_checkpoint_name: str = "best.pt"
+    last_checkpoint_name: str = "last.pt"
 
 
 class Trainer:
@@ -31,10 +289,27 @@ class Trainer:
         self.config = config
         self.device = self._resolve_device(config.device)
         self.model.to(self.device)
-        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=config.learning_rate)
+        self.optimizer = _build_optimizer(self.model.parameters(), config)
+        (
+            self._amp_enabled,
+            self._autocast_device,
+            self._autocast_dtype,
+            scaler_enabled,
+        ) = _resolve_autocast_settings(self.device, config)
+        self.scaler: Optional[_GradScalerBase]
+        if self._amp_enabled and self._autocast_device == "cuda":
+            self.scaler = _make_grad_scaler(enabled=scaler_enabled)
+        else:
+            self.scaler = None
+        self.scheduler: Optional[WarmupDecayScheduler] = None
         self.criterion = nn.MSELoss()
         self.output_dir = config.output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.history: Dict[str, float] = {}
+        self.best_checkpoint_path: Optional[Path] = None
+        self.last_checkpoint_path: Optional[Path] = None
+        self._best_metric: Optional[float] = None
+        self._early_stop_counter = 0
 
     def _resolve_device(self, device: str) -> torch.device:
         if device == "auto":
@@ -47,15 +322,47 @@ class Trainer:
 
     def train(self, dataloader: DataLoader, *, val_loader: Optional[DataLoader] = None) -> Dict[str, float]:
         history: Dict[str, float] = {}
+        train_samples = len(getattr(dataloader, "dataset", []))
+        val_samples = len(getattr(val_loader, "dataset", [])) if val_loader is not None else 0
+        try:
+            steps_per_epoch = len(dataloader)
+        except TypeError:
+            steps_per_epoch = None
+        self.scheduler = _maybe_build_scheduler(self.optimizer, self.config, steps_per_epoch)
+        summary = f"Starting training for {self.config.epochs} epochs on {train_samples} samples"
+        if val_loader is not None:
+            summary += f" with {val_samples} validation samples"
+        summary += f" | optimizer={self.config.optimizer}"
+        if self.scheduler is not None:
+            summary += f", scheduler={self.config.scheduler}"
+            if self.config.warmup_steps > 0:
+                summary += f" (warmup={self.config.warmup_steps})"
+        _emit_info(summary)
+        log_interval = max(int(self.config.log_every), 1)
         for epoch in range(1, self.config.epochs + 1):
             train_loss = self._run_epoch(dataloader, training=True)
             history[f"train/{epoch}"] = train_loss
+            val_loss: Optional[float] = None
             if val_loader is not None:
                 val_loss = self._run_epoch(val_loader, training=False)
                 history[f"val/{epoch}"] = val_loss
-            if epoch % self.config.log_every == 0:
-                print(f"Epoch {epoch:03d} | train: {train_loss:.4f}"
-                      + (f" | val: {val_loss:.4f}" if val_loader is not None else ""))
+            if epoch == 1 or epoch == self.config.epochs or epoch % log_interval == 0:
+                message = f"Epoch {epoch:03d} | train: {train_loss:.4f}"
+                if val_loss is not None:
+                    message += f" | val: {val_loss:.4f}"
+                _emit_info(message)
+            if self.scheduler is not None:
+                lr_value = float(self.scheduler.get_last_lr()[0])
+                history[f"lr/{epoch}"] = lr_value
+            self._update_checkpoints(train_loss, val_loss)
+            if self._should_stop_early(val_loss):
+                _emit_info(
+                    "Early stopping triggered after epoch %03d (best %.4f)"
+                    % (epoch, self._best_metric if self._best_metric is not None else train_loss)
+                )
+                break
+        self.history = history
+        _save_history(self.output_dir, history)
         return history
 
     def _run_epoch(self, dataloader: DataLoader, *, training: bool) -> float:
@@ -67,21 +374,71 @@ class Trainer:
             inputs = inputs.to(self.device)
             targets = targets.to(self.device)
             if training:
-                self.optimizer.zero_grad()
-            outputs = self.model(inputs)
-            loss = self.criterion(outputs, targets)
+                self.optimizer.zero_grad(set_to_none=True)
+            with _autocast_context(
+                self._amp_enabled, self._autocast_device, self._autocast_dtype
+            ):
+                outputs = self.model(inputs)
+                loss = self.criterion(outputs, targets)
             if training:
-                loss.backward()
-                self.optimizer.step()
+                if self.scaler is not None:
+                    scaled_loss = self.scaler.scale(loss)
+                    scaled_loss.backward()
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                else:
+                    loss.backward()
+                    self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
             total_loss += loss.item()
             n_batches += 1
         return total_loss / max(n_batches, 1)
 
     def save_checkpoint(self, path: Path) -> None:
-        torch.save({
+        self._save_checkpoint(path)
+
+    def _checkpoint_state(self) -> Dict[str, object]:
+        return {
             "model_state": self.model.state_dict(),
             "config": self.config,
-        }, path)
+        }
+
+    def _save_checkpoint(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(self._checkpoint_state(), path)
+        return path
+
+    def _resolve_checkpoint_name(self, filename: str) -> Path:
+        return self.output_dir / filename
+
+    def _update_checkpoints(self, train_loss: float, val_loss: Optional[float]) -> None:
+        monitor = val_loss if val_loss is not None else train_loss
+        if monitor is None:
+            return
+        improved = False
+        if self._best_metric is None or (
+            monitor < self._best_metric - float(self.config.early_stopping_min_delta)
+        ):
+            self._best_metric = monitor
+            self._early_stop_counter = 0
+            if self.config.best_checkpoint_name:
+                path = self._resolve_checkpoint_name(self.config.best_checkpoint_name)
+                self.best_checkpoint_path = self._save_checkpoint(path)
+                _emit_info(
+                    "New best checkpoint saved to %s (loss=%.4f)" % (path, float(monitor))
+                )
+            improved = True
+        if not improved and val_loss is not None and self.config.early_stopping_patience > 0:
+            self._early_stop_counter += 1
+        if self.config.last_checkpoint_name:
+            path = self._resolve_checkpoint_name(self.config.last_checkpoint_name)
+            self.last_checkpoint_path = self._save_checkpoint(path)
+
+    def _should_stop_early(self, val_loss: Optional[float]) -> bool:
+        if val_loss is None or self.config.early_stopping_patience <= 0:
+            return False
+        return self._early_stop_counter >= self.config.early_stopping_patience
 
 
 class TensorDataset(Dataset):
@@ -98,19 +455,425 @@ class TensorDataset(Dataset):
         return self.inputs[index], self.targets[index]
 
 
-def train_baseline(formula_vectors: torch.Tensor, energies: torch.Tensor, *, species: Sequence[int], config: TrainingConfig) -> Trainer:
+def _solve_least_squares(
+    model: LinearAtomicBaseline,
+    dataset: TensorDataset,
+    *,
+    train_indices: Sequence[int],
+    val_indices: Sequence[int],
+    output_dir: Path,
+) -> Dict[str, float]:
+    train_indices = list(train_indices)
+    val_indices = list(val_indices)
+    if not train_indices:
+        raise ValueError("Least squares solver requires at least one training sample")
+    train_inputs = dataset.inputs[train_indices]
+    train_targets = dataset.targets[train_indices]
+    _emit_info(
+        "Fitting baseline with closed-form least squares on %d samples%s"
+        % (
+            len(train_indices),
+            f" and {len(val_indices)} validation samples" if val_indices else "",
+        )
+    )
+    with torch.no_grad():
+        solution = torch.linalg.lstsq(
+            train_inputs.to(torch.float64), train_targets.to(torch.float64).unsqueeze(-1)
+        ).solution.squeeze(-1)
+        model.linear.weight.data.copy_(solution.to(train_inputs.dtype).unsqueeze(0))
+    history: Dict[str, float] = {}
+    with torch.no_grad():
+        train_predictions = model(train_inputs)
+        train_loss = torch.mean((train_predictions - train_targets) ** 2).item()
+        history["train/1"] = train_loss
+        if val_indices:
+            val_inputs = dataset.inputs[val_indices]
+            val_targets = dataset.targets[val_indices]
+            val_predictions = model(val_inputs)
+            val_loss = torch.mean((val_predictions - val_targets) ** 2).item()
+            history["val/1"] = val_loss
+    message = f"Least squares fit | train: {train_loss:.4f}"
+    if "val/1" in history:
+        message += f" | val: {history['val/1']:.4f}"
+    _emit_info(message)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _save_history(output_dir, history)
+    return history
+
+
+def train_baseline(
+    formula_vectors: torch.Tensor,
+    energies: torch.Tensor,
+    *,
+    species: Sequence[int],
+    config: TrainingConfig,
+) -> Trainer:
     dataset = TensorDataset(formula_vectors, energies)
     val_size = int(len(dataset) * config.validation_split)
     if val_size > 0:
         train_size = len(dataset) - val_size
         train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
         val_loader = DataLoader(val_dataset, batch_size=config.batch_size, shuffle=False)
+        train_indices = list(train_dataset.indices)  # type: ignore[attr-defined]
+        val_indices = list(val_dataset.indices)  # type: ignore[attr-defined]
     else:
         train_dataset = dataset
         val_loader = None
-    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=True)
+        train_indices = list(range(len(dataset)))
+        val_indices = []
     baseline_config = LinearBaselineConfig(species=tuple(species))
     model = LinearAtomicBaseline(baseline_config)
+    solver = getattr(config, "solver", "optimizer").lower()
+    if solver in {"least_squares", "ols", "linear_regression"}:
+        history = _solve_least_squares(
+            model,
+            dataset,
+            train_indices=train_indices,
+            val_indices=val_indices,
+            output_dir=config.output_dir,
+        )
+        trainer = Trainer(model, config)
+        trainer.history = history
+        monitor = history.get("val/1", history.get("train/1"))
+        if monitor is not None:
+            trainer._best_metric = monitor
+        if config.best_checkpoint_name:
+            path = trainer._resolve_checkpoint_name(config.best_checkpoint_name)
+            trainer.best_checkpoint_path = trainer._save_checkpoint(path)
+            if monitor is not None:
+                _emit_info(
+                    "New best checkpoint saved to %s (loss=%.4f)" % (path, float(monitor))
+                )
+        if config.last_checkpoint_name:
+            path = trainer._resolve_checkpoint_name(config.last_checkpoint_name)
+            trainer.last_checkpoint_path = trainer._save_checkpoint(path)
+        return trainer
+    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=True)
     trainer = Trainer(model, config)
+    trainer.train(train_loader, val_loader=val_loader)
+    return trainer
+
+
+@dataclass
+class PotentialTrainingConfig(TrainingConfig):
+    """Configuration for potential energy/force training."""
+
+    energy_weight: float = 1.0
+    force_weight: float = 0.0
+    predict_forces_directly: bool = False
+    max_grad_norm: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.best_checkpoint_name == "best.pt":
+            self.best_checkpoint_name = "potential_best.pt"
+        if self.last_checkpoint_name == "last.pt":
+            self.last_checkpoint_name = "potential_last.pt"
+
+
+class PotentialTrainer:
+    """Trainer that optimizes potential models for energies and forces."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        config: PotentialTrainingConfig,
+        *,
+        baseline: Optional[LinearAtomicBaseline] = None,
+        baseline_requires_grad: bool = True,
+    ) -> None:
+        self.model = model
+        self.config = config
+        self.device = self._resolve_device(config.device)
+        self.model.to(self.device)
+        parameters = list(self.model.parameters())
+        self.scheduler: Optional[WarmupDecayScheduler] = None
+        self.energy_loss = nn.MSELoss()
+        self.force_loss = nn.MSELoss()
+        self.output_dir = config.output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.baseline = baseline
+        self.baseline_trainable = baseline is not None and baseline_requires_grad
+        self.history: Dict[str, float] = {}
+        self.best_checkpoint_path: Optional[Path] = None
+        self.last_checkpoint_path: Optional[Path] = None
+        self._best_metric: Optional[float] = None
+        self._early_stop_counter = 0
+        if self.baseline is not None:
+            self.baseline.to(self.device)
+            if self.baseline_trainable:
+                for param in self.baseline.parameters():
+                    param.requires_grad_(True)
+                parameters.extend(self.baseline.parameters())
+            else:
+                self.baseline.eval()
+                for param in self.baseline.parameters():
+                    param.requires_grad_(False)
+        self.optimizer = _build_optimizer(parameters, config)
+        (
+            self._amp_enabled,
+            self._autocast_device,
+            self._autocast_dtype,
+            scaler_enabled,
+        ) = _resolve_autocast_settings(self.device, config)
+        self.scaler: Optional[_GradScalerBase]
+        if self._amp_enabled and self._autocast_device == "cuda":
+            self.scaler = _make_grad_scaler(enabled=scaler_enabled)
+        else:
+            self.scaler = None
+
+    def _resolve_device(self, device: str) -> torch.device:
+        if device == "auto":
+            if torch.cuda.is_available():
+                return torch.device("cuda")
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                return torch.device("mps")
+            return torch.device("cpu")
+        return torch.device(device)
+
+    def train(self, dataloader: DataLoader, *, val_loader: Optional[DataLoader] = None) -> Dict[str, float]:
+        history: Dict[str, float] = {}
+        train_samples = len(getattr(dataloader, "dataset", []))
+        val_samples = len(getattr(val_loader, "dataset", [])) if val_loader is not None else 0
+        summary = (
+            f"Starting potential training for {self.config.epochs} epochs on {train_samples} samples"
+        )
+        if val_loader is not None:
+            summary += f" with {val_samples} validation samples"
+        details = [f"energy weight={self.config.energy_weight}"]
+        if self.config.force_weight > 0.0:
+            details.append(f"force weight={self.config.force_weight}")
+            if self.config.predict_forces_directly:
+                details.append("predicting forces directly")
+        try:
+            steps_per_epoch = len(dataloader)
+        except TypeError:
+            steps_per_epoch = None
+        self.scheduler = _maybe_build_scheduler(self.optimizer, self.config, steps_per_epoch)
+        details.append(f"optimizer={self.config.optimizer}")
+        if self.scheduler is not None:
+            schedule_msg = f"scheduler={self.config.scheduler}"
+            if self.config.warmup_steps > 0:
+                schedule_msg += f" (warmup={self.config.warmup_steps})"
+            details.append(schedule_msg)
+        if details:
+            summary += " (" + ", ".join(details) + ")"
+        _emit_info(summary)
+        log_interval = max(int(self.config.log_every), 1)
+        for epoch in range(1, self.config.epochs + 1):
+            train_metrics = self._run_epoch(dataloader, training=True)
+            history[f"train/{epoch}"] = train_metrics["loss"]
+            val_metrics: Optional[Dict[str, float]] = None
+            if val_loader is not None:
+                val_metrics = self._run_epoch(val_loader, training=False)
+                history[f"val/{epoch}"] = val_metrics["loss"]
+            if epoch == 1 or epoch == self.config.epochs or epoch % log_interval == 0:
+                message = f"Epoch {epoch:03d} | train: {train_metrics['loss']:.4f}"
+                if val_metrics is not None:
+                    message += f" | val: {val_metrics['loss']:.4f}"
+                _emit_info(message)
+            if self.scheduler is not None:
+                history[f"lr/{epoch}"] = float(self.scheduler.get_last_lr()[0])
+            val_loss = val_metrics["loss"] if val_metrics is not None else None
+            self._update_checkpoints(train_metrics["loss"], val_loss)
+            if self._should_stop_early(val_loss):
+                _emit_info(
+                    "Early stopping triggered after epoch %03d (best %.4f)"
+                    % (
+                        epoch,
+                        self._best_metric if self._best_metric is not None else train_metrics["loss"],
+                    )
+                )
+                break
+        self.history = history
+        _save_history(self.output_dir, history)
+        return history
+
+    def _run_epoch(self, dataloader: DataLoader, *, training: bool) -> Dict[str, float]:
+        self.model.train(mode=training)
+        if self.baseline is not None:
+            if self.baseline_trainable:
+                self.baseline.train(mode=training)
+            else:
+                self.baseline.eval()
+        total_loss = 0.0
+        total_energy_loss = 0.0
+        total_force_loss = 0.0
+        n_batches = 0
+        for batch in dataloader:
+            batch = {key: value.to(self.device) for key, value in batch.items() if isinstance(value, torch.Tensor)}
+            energies = batch["energies"]
+            formula_vectors = batch["formula_vectors"]
+            requires_force_grad = (
+                self.config.force_weight > 0.0
+                and not self.config.predict_forces_directly
+                and batch.get("forces") is not None
+            )
+            positions = batch["positions"]
+            if requires_force_grad:
+                positions = positions.clone().detach().requires_grad_(True)
+                batch["positions"] = positions
+            if training:
+                self.optimizer.zero_grad(set_to_none=True)
+            force_loss_value = torch.tensor(0.0, device=self.device)
+            with torch.set_grad_enabled(training or requires_force_grad):
+                with _autocast_context(
+                    self._amp_enabled, self._autocast_device, self._autocast_dtype
+                ):
+                    baseline_energy = None
+                    if self.baseline is not None:
+                        baseline_training = self.baseline_trainable and training
+                        baseline_ctx = nullcontext() if baseline_training else torch.no_grad()
+                        with baseline_ctx:
+                            baseline_energy = self.baseline(formula_vectors)
+                        if baseline_energy is not None and not baseline_training:
+                            baseline_energy = baseline_energy.detach()
+                        target_energy = energies - baseline_energy
+                    else:
+                        target_energy = energies
+                    output = self._forward_model(batch)
+                    energy_pred = output.energy
+                    energy_loss = self.energy_loss(energy_pred, target_energy)
+                    loss = self.config.energy_weight * energy_loss
+                    if batch.get("forces") is not None and self.config.force_weight > 0.0:
+                        if output.forces is not None and self.config.predict_forces_directly:
+                            predicted_forces = output.forces
+                        else:
+                            grads = torch.autograd.grad(
+                                energy_pred.sum(),
+                                positions,
+                                create_graph=training,
+                                retain_graph=training,
+                            )[0]
+                            predicted_forces = -grads
+                        mask = batch["mask"].unsqueeze(-1)
+                        target_forces = batch["forces"] * mask
+                        predicted_forces = predicted_forces * mask
+                        force_loss_value = self.force_loss(predicted_forces, target_forces)
+                        loss = loss + self.config.force_weight * force_loss_value
+            if training:
+                if self.scaler is not None:
+                    scaled_loss = self.scaler.scale(loss)
+                    scaled_loss.backward()
+                    if self.config.max_grad_norm is not None:
+                        self.scaler.unscale_(self.optimizer)
+                        params_to_clip = list(self.model.parameters())
+                        if self.baseline is not None and self.baseline_trainable:
+                            params_to_clip += list(self.baseline.parameters())
+                        nn.utils.clip_grad_norm_(params_to_clip, self.config.max_grad_norm)
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                else:
+                    loss.backward()
+                    if self.config.max_grad_norm is not None:
+                        params_to_clip = list(self.model.parameters())
+                        if self.baseline is not None and self.baseline_trainable:
+                            params_to_clip += list(self.baseline.parameters())
+                        nn.utils.clip_grad_norm_(params_to_clip, self.config.max_grad_norm)
+                    self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
+            total_loss += loss.item()
+            total_energy_loss += energy_loss.item()
+            total_force_loss += force_loss_value.item()
+            n_batches += 1
+        metrics = {
+            "loss": total_loss / max(n_batches, 1),
+            "energy_loss": total_energy_loss / max(n_batches, 1),
+        }
+        if self.config.force_weight > 0.0:
+            metrics["force_loss"] = total_force_loss / max(n_batches, 1)
+        return metrics
+
+    def _forward_model(self, batch: Dict[str, torch.Tensor]) -> PotentialOutput:
+        return self.model(
+            batch["node_indices"],
+            batch["positions"],
+            batch["adjacency"],
+            batch["mask"],
+        )
+
+    def save_checkpoint(self, path: Path) -> None:
+        self._save_checkpoint(path)
+
+    def _checkpoint_state(self) -> Dict[str, object]:
+        state: Dict[str, object] = {
+            "model_state": self.model.state_dict(),
+            "config": self.config,
+        }
+        if self.baseline is not None:
+            state["baseline_state"] = self.baseline.state_dict()
+            state["baseline_trainable"] = self.baseline_trainable
+        return state
+
+    def _save_checkpoint(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(self._checkpoint_state(), path)
+        return path
+
+    def _resolve_checkpoint_name(self, filename: str) -> Path:
+        return self.output_dir / filename
+
+    def _update_checkpoints(self, train_loss: float, val_loss: Optional[float]) -> None:
+        monitor = val_loss if val_loss is not None else train_loss
+        if monitor is None:
+            return
+        improved = False
+        if self._best_metric is None or (
+            monitor < self._best_metric - float(self.config.early_stopping_min_delta)
+        ):
+            self._best_metric = monitor
+            self._early_stop_counter = 0
+            if self.config.best_checkpoint_name:
+                path = self._resolve_checkpoint_name(self.config.best_checkpoint_name)
+                self.best_checkpoint_path = self._save_checkpoint(path)
+                _emit_info(
+                    "New best checkpoint saved to %s (loss=%.4f)" % (path, float(monitor))
+                )
+            improved = True
+        if not improved and val_loss is not None and self.config.early_stopping_patience > 0:
+            self._early_stop_counter += 1
+        if self.config.last_checkpoint_name:
+            path = self._resolve_checkpoint_name(self.config.last_checkpoint_name)
+            self.last_checkpoint_path = self._save_checkpoint(path)
+
+    def _should_stop_early(self, val_loss: Optional[float]) -> bool:
+        if val_loss is None or self.config.early_stopping_patience <= 0:
+            return False
+        return self._early_stop_counter >= self.config.early_stopping_patience
+
+
+def train_potential_model(
+    dataset: MolecularGraphDataset,
+    model: nn.Module,
+    *,
+    config: PotentialTrainingConfig,
+    baseline: Optional[LinearAtomicBaseline] = None,
+    baseline_requires_grad: bool = True,
+) -> PotentialTrainer:
+    val_size = int(len(dataset) * config.validation_split)
+    if val_size > 0:
+        train_size = len(dataset) - val_size
+        train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
+        val_loader = DataLoader(
+            val_dataset,
+            batch_size=config.batch_size,
+            shuffle=False,
+            collate_fn=collate_graphs,
+        )
+    else:
+        train_dataset = dataset
+        val_loader = None
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=config.batch_size,
+        shuffle=True,
+        collate_fn=collate_graphs,
+    )
+    trainer = PotentialTrainer(
+        model,
+        config,
+        baseline=baseline,
+        baseline_requires_grad=baseline_requires_grad,
+    )
     trainer.train(train_loader, val_loader=val_loader)
     return trainer

--- a/deltamol/utils/logging.py
+++ b/deltamol/utils/logging.py
@@ -15,4 +15,5 @@ def configure_logging(output_dir: Path, level: int = logging.INFO) -> None:
             logging.FileHandler(log_path),
             logging.StreamHandler(),
         ],
+        force=True,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from deltamol.config.manager import load_config, save_config
+
+
+@dataclass
+class InnerConfig:
+    path: Path
+    values: tuple[int, ...]
+
+
+@dataclass
+class OuterConfig:
+    inner: InnerConfig
+    names: tuple[str, ...]
+
+
+def test_nested_config_roundtrip(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    original = OuterConfig(
+        inner=InnerConfig(path=tmp_path / "data", values=(1, 2, 3)),
+        names=("alpha", "beta"),
+    )
+
+    save_config(original, config_path)
+    loaded = load_config(config_path, OuterConfig)
+
+    assert loaded == original

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,11 @@
 import numpy as np
 import pytest
 
+torch = pytest.importorskip("torch")
+
 from deltamol.data.io import load_npz_dataset
+from deltamol.data.io import MolecularDataset
+from deltamol.training.datasets import MolecularGraphDataset, collate_graphs
 
 
 def test_load_npz_dataset(tmp_path):
@@ -24,3 +28,42 @@ def test_load_npz_dataset(tmp_path):
     assert dataset.coordinates.shape[0] == 2
     assert dataset.energies.tolist() == pytest.approx([-76.4, -40.2], abs=1e-5)
     assert dataset.metadata["split"].tolist() == [1, 2]
+
+
+def test_molecular_graph_dataset_and_collate():
+    atoms = np.array([
+        np.array([1, 8, 1]),
+        np.array([6, 1]),
+    ], dtype=object)
+    coordinates = np.array([
+        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.9, -0.3]], dtype=np.float32),
+        np.array([[0.0, 0.0, 0.0], [1.1, 0.0, 0.0]], dtype=np.float32),
+    ], dtype=object)
+    energies = np.array([-76.4, -40.2], dtype=np.float32)
+    forces = np.array([
+        np.zeros((3, 3), dtype=np.float32),
+        np.zeros((2, 3), dtype=np.float32),
+    ], dtype=object)
+    dataset = MolecularDataset(atoms=atoms, coordinates=coordinates, energies=energies, forces=forces)
+
+    graph_dataset = MolecularGraphDataset(dataset, cutoff=2.5)
+    batch = collate_graphs([graph_dataset[0], graph_dataset[1]])
+
+    assert batch["node_indices"].shape == (2, 3)
+    assert batch["positions"].shape[-1] == 3
+    assert batch["mask"].dtype == torch.bool
+    assert torch.allclose(batch["energies"], torch.tensor([-76.4, -40.2]))
+    assert "forces" in batch
+    assert batch["forces"].shape == (2, 3, 3)
+
+
+def test_molecular_graph_dataset_accepts_string_dtype():
+    atoms = np.array([np.array([1, 1])], dtype=object)
+    coordinates = np.array([np.zeros((2, 3), dtype=np.float32)], dtype=object)
+    energies = np.array([-1.23], dtype=np.float32)
+    dataset = MolecularDataset(atoms=atoms, coordinates=coordinates, energies=energies, forces=None)
+
+    graph_dataset = MolecularGraphDataset(dataset, cutoff=3.0, dtype="float64")
+
+    graph = graph_dataset[0]
+    assert graph.positions.dtype == torch.float64

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,3 +31,33 @@ def test_run_baseline_training_creates_checkpoint(tmp_path):
     )
 
     assert (output_dir / "baseline.pt").exists()
+
+
+def test_run_baseline_training_least_squares(tmp_path):
+    dataset_path = tmp_path / "dataset_ls.npz"
+    atoms = np.array([
+        np.array([1, 6]),
+        np.array([6, 8]),
+        np.array([1, 8, 8]),
+    ], dtype=object)
+    coordinates = np.array([
+        np.zeros((2, 3), dtype=np.float32),
+        np.ones((2, 3), dtype=np.float32),
+        np.ones((3, 3), dtype=np.float32),
+    ], dtype=object)
+    energies = np.array([-1.0, -2.5, -3.0], dtype=np.float32)
+    np.savez(dataset_path, atoms=atoms, coordinates=coordinates, Etot=energies)
+
+    output_dir = tmp_path / "run_ls"
+
+    run_baseline_training(
+        dataset_path,
+        output_dir,
+        epochs=1,
+        batch_size=3,
+        learning_rate=1e-2,
+        validation_split=0.0,
+        solver="least_squares",
+    )
+
+    assert (output_dir / "baseline.pt").exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,8 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from deltamol.models.baseline import build_formula_vector
+from deltamol.models.gcn import GCNConfig, GCNPotential
+from deltamol.models.transformer import TransformerConfig, TransformerPotential
 
 
 def test_build_formula_vector_counts_species():
@@ -12,3 +14,35 @@ def test_build_formula_vector_counts_species():
     vector = build_formula_vector(atoms, species=species)
 
     assert torch.allclose(vector, torch.tensor([1.0, 1.0, 2.0]))
+
+
+def test_gcn_forward_pass_runs():
+    species = (1, 6, 8)
+    config = GCNConfig(species=species, hidden_dim=16, num_layers=2, predict_forces=True)
+    model = GCNPotential(config)
+    node_indices = torch.tensor([[1, 2, 3, 0], [3, 1, 0, 0]], dtype=torch.long)
+    positions = torch.randn(2, 4, 3)
+    adjacency = torch.eye(4).repeat(2, 1, 1)
+    mask = node_indices != 0
+
+    output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (2,)
+    assert output.forces is not None
+    assert output.forces.shape == (2, 4, 3)
+
+
+def test_transformer_forward_pass_runs():
+    species = (1, 6)
+    config = TransformerConfig(species=species, hidden_dim=8, num_layers=1, num_heads=2, predict_forces=True)
+    model = TransformerPotential(config)
+    node_indices = torch.tensor([[1, 2, 0], [2, 1, 1]], dtype=torch.long)
+    positions = torch.randn(2, 3, 3)
+    adjacency = torch.eye(3).repeat(2, 1, 1)
+    mask = node_indices != 0
+
+    output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (2,)
+    assert output.forces is not None
+    assert output.forces.shape == (2, 3, 3)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,308 @@
+import json
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from deltamol.models.baseline import LinearAtomicBaseline, LinearBaselineConfig
+from deltamol.models.potential import PotentialOutput
+from deltamol.training.pipeline import (
+    PotentialTrainer,
+    PotentialTrainingConfig,
+    TensorDataset,
+    Trainer,
+    TrainingConfig,
+    train_baseline,
+)
+
+
+def test_trainer_persists_history(tmp_path):
+    torch.manual_seed(0)
+    inputs = torch.randn(8, 3)
+    weights = torch.tensor([[1.0], [-2.0], [0.5]])
+    targets = inputs @ weights
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model = nn.Sequential(nn.Linear(3, 8), nn.ReLU(), nn.Linear(8, 1))
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=3,
+        learning_rate=1e-2,
+        batch_size=4,
+        log_every=1,
+    )
+    trainer = Trainer(model, config)
+
+    history = trainer.train(loader)
+
+    assert history == trainer.history
+    final_key = f"train/{config.epochs}"
+    assert final_key in history
+    history_path = tmp_path / "history.json"
+    assert history_path.exists()
+    with history_path.open("r", encoding="utf-8") as handle:
+        saved = json.load(handle)
+    assert saved == history
+    assert trainer.best_checkpoint_path == tmp_path / config.best_checkpoint_name
+    assert trainer.last_checkpoint_path == tmp_path / config.last_checkpoint_name
+    assert trainer.best_checkpoint_path.exists()
+    assert trainer.last_checkpoint_path.exists()
+
+
+def test_trainer_supports_optimizer_and_scheduler(tmp_path):
+    torch.manual_seed(1)
+    inputs = torch.randn(16, 4)
+    weights = torch.tensor([[0.5], [-1.0], [1.5], [0.25]])
+    targets = inputs @ weights
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model = nn.Sequential(nn.Linear(4, 8), nn.ReLU(), nn.Linear(8, 1))
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=2,
+        learning_rate=5e-3,
+        batch_size=4,
+        optimizer="adamw",
+        weight_decay=0.01,
+        scheduler="linear",
+        warmup_steps=2,
+        scheduler_total_steps=8,
+        min_lr_ratio=0.2,
+    )
+    trainer = Trainer(model, config)
+
+    trainer.train(loader)
+
+    assert trainer.scheduler is not None
+    final_lr = trainer.scheduler.get_last_lr()[0]
+    expected_lr = config.learning_rate * config.min_lr_ratio
+    assert pytest.approx(expected_lr, rel=1e-5) == final_lr
+    lr_keys = [key for key in trainer.history if key.startswith("lr/")]
+    assert lr_keys, "learning rate history should be recorded when scheduler is active"
+
+
+def test_trainer_enables_mixed_precision_cpu(tmp_path):
+    torch.manual_seed(0)
+    inputs = torch.randn(8, 3)
+    targets = torch.randn(8, 1)
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+
+    class _AutocastRecorder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = nn.Sequential(nn.Linear(3, 8), nn.ReLU(), nn.Linear(8, 1))
+            self.output_dtypes = []
+            self.autocast_states = []
+
+        def forward(self, x):
+            out = self.model(x)
+            self.output_dtypes.append(out.dtype)
+            try:
+                state = torch.is_autocast_enabled(x.device.type)
+            except TypeError:  # pragma: no cover - compatibility fallback
+                state = torch.is_autocast_enabled()
+            self.autocast_states.append(state)
+            return out
+
+    model = _AutocastRecorder()
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=1,
+        batch_size=4,
+        mixed_precision=True,
+        autocast_dtype="bfloat16",
+    )
+    trainer = Trainer(model, config)
+
+    trainer.train(loader)
+
+    assert torch.bfloat16 in model.output_dtypes
+    assert any(model.autocast_states)
+    assert trainer.scaler is None
+
+
+def test_train_baseline_least_squares(tmp_path):
+    torch.manual_seed(0)
+    formula_vectors = torch.tensor(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+    true_weights = torch.tensor([1.5, -0.75, 0.25], dtype=torch.float32)
+    energies = formula_vectors @ true_weights
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        solver="least_squares",
+        validation_split=0.25,
+    )
+    trainer = train_baseline(
+        formula_vectors,
+        energies,
+        species=[1, 6, 8],
+        config=config,
+    )
+    learned = trainer.model.linear.weight.detach().cpu().squeeze(0)
+    assert torch.allclose(learned, true_weights, atol=1e-6)
+    assert pytest.approx(0.0, abs=1e-8) == trainer.history["train/1"]
+    if "val/1" in trainer.history:
+        assert pytest.approx(0.0, abs=1e-8) == trainer.history["val/1"]
+    history_path = tmp_path / "history.json"
+    assert history_path.exists()
+    assert trainer.best_checkpoint_path == tmp_path / config.best_checkpoint_name
+    assert trainer.last_checkpoint_path == tmp_path / config.last_checkpoint_name
+    assert trainer.best_checkpoint_path.exists()
+    assert trainer.last_checkpoint_path.exists()
+
+
+def test_trainer_early_stopping_and_checkpoints(tmp_path):
+    torch.manual_seed(0)
+    inputs = torch.randn(12, 2)
+    targets = torch.randn(12, 1)
+    dataset = TensorDataset(inputs, targets)
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    val_loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model = nn.Sequential(nn.Linear(2, 4), nn.ReLU(), nn.Linear(4, 1))
+    config = TrainingConfig(
+        output_dir=tmp_path,
+        epochs=5,
+        learning_rate=0.0,
+        batch_size=4,
+        log_every=1,
+        early_stopping_patience=1,
+        best_checkpoint_name="best.pt",
+        last_checkpoint_name="last.pt",
+    )
+    trainer = Trainer(model, config)
+
+    trainer.train(loader, val_loader=val_loader)
+
+    assert "train/5" not in trainer.history
+    assert trainer.best_checkpoint_path.exists()
+    assert trainer.last_checkpoint_path.exists()
+    assert trainer.best_checkpoint_path == tmp_path / "best.pt"
+    assert trainer.last_checkpoint_path == tmp_path / "last.pt"
+
+
+class _ToyPotentialDataset(Dataset):
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return 1
+
+    def __getitem__(self, index: int):  # pragma: no cover - trivial
+        return {
+            "energies": torch.tensor([1.0], dtype=torch.float32),
+            "formula_vectors": torch.tensor([[1.0]], dtype=torch.float32),
+            "positions": torch.zeros(1, 1, 3, dtype=torch.float32),
+            "mask": torch.tensor([[1.0]], dtype=torch.float32),
+            "node_indices": torch.tensor([[1]], dtype=torch.long),
+            "adjacency": torch.ones(1, 1, 1, dtype=torch.float32),
+        }
+
+
+class _ZeroPotential(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.offset = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, node_indices, positions, adjacency, mask):  # pragma: no cover - simple
+        batch_size = node_indices.size(0)
+        energy = torch.zeros(batch_size, device=node_indices.device) + self.offset
+        return PotentialOutput(energy=energy)
+
+
+def test_potential_trainer_baseline_requires_grad(tmp_path):
+    dataset = _ToyPotentialDataset()
+    loader = DataLoader(dataset, batch_size=1, collate_fn=lambda batch: batch[0])
+    baseline_config = LinearBaselineConfig(species=(1,))
+
+    trainable_dir = tmp_path / "trainable"
+    trainable_config = PotentialTrainingConfig(
+        output_dir=trainable_dir,
+        epochs=1,
+        learning_rate=0.1,
+        batch_size=1,
+        validation_split=0.0,
+    )
+    baseline = LinearAtomicBaseline(baseline_config)
+    baseline.linear.weight.data.zero_()
+    trainer = PotentialTrainer(
+        _ZeroPotential(),
+        trainable_config,
+        baseline=baseline,
+        baseline_requires_grad=True,
+    )
+    trainer.train(loader)
+    assert not torch.allclose(
+        baseline.linear.weight.detach(), torch.zeros_like(baseline.linear.weight)
+    )
+    assert trainer.best_checkpoint_path == trainable_dir / trainable_config.best_checkpoint_name
+    assert trainer.last_checkpoint_path == trainable_dir / trainable_config.last_checkpoint_name
+    assert trainer.best_checkpoint_path.exists()
+    assert trainer.last_checkpoint_path.exists()
+
+    frozen_dir = tmp_path / "frozen"
+    frozen_config = PotentialTrainingConfig(
+        output_dir=frozen_dir,
+        epochs=1,
+        learning_rate=0.1,
+        batch_size=1,
+        validation_split=0.0,
+    )
+    frozen_baseline = LinearAtomicBaseline(baseline_config)
+    frozen_baseline.linear.weight.data.zero_()
+    trainer_frozen = PotentialTrainer(
+        _ZeroPotential(),
+        frozen_config,
+        baseline=frozen_baseline,
+        baseline_requires_grad=False,
+    )
+    trainer_frozen.train(loader)
+    assert torch.allclose(
+        frozen_baseline.linear.weight.detach(), torch.zeros_like(frozen_baseline.linear.weight)
+    )
+
+
+def test_potential_trainer_mixed_precision_cpu(tmp_path):
+    dataset = _ToyPotentialDataset()
+    loader = DataLoader(dataset, batch_size=1, collate_fn=lambda batch: batch[0])
+
+    class _AutocastPotential(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(1, 1)
+            self.recorded_dtypes = []
+            self.autocast_states = []
+
+        def forward(self, node_indices, positions, adjacency, mask):
+            pooled = mask.sum(dim=1, keepdim=True)
+            energy = self.linear(pooled).squeeze(-1)
+            self.recorded_dtypes.append(energy.dtype)
+            try:
+                state = torch.is_autocast_enabled(energy.device.type)
+            except TypeError:  # pragma: no cover - compatibility fallback
+                state = torch.is_autocast_enabled()
+            self.autocast_states.append(state)
+            return PotentialOutput(energy=energy)
+
+    model = _AutocastPotential()
+    config = PotentialTrainingConfig(
+        output_dir=tmp_path,
+        epochs=1,
+        batch_size=1,
+        validation_split=0.0,
+        mixed_precision=True,
+        autocast_dtype="bfloat16",
+    )
+    trainer = PotentialTrainer(model, config)
+
+    trainer.train(loader)
+
+    assert torch.bfloat16 in model.recorded_dtypes
+    assert any(model.autocast_states)
+    assert trainer.scaler is None


### PR DESCRIPTION
## Summary
- add automatic mixed precision support to the baseline and potential trainers with configurable autocast dtypes and gradient scaling
- expose mixed precision flags through the CLI, baseline entry point, and documentation so runs can opt into the new settings
- cover the AMP pathways with unit tests that assert CPU autocast engages and preserves histories

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7fb441bc832fbcffeb7a653b9439