### PR TITLE
Add LEFTNet potential architecture

### DIFF
--- a/deltamol/cli/__init__.py
+++ b/deltamol/cli/__init__.py
@@ -42,6 +42,8 @@ from ..models import (
     GemNetPotential,
     MACEConfig,
     MACEPotential,
+    LeftNetConfig,
+    LeftNetPotential,
     TensorNetConfig,
     TensorNetPotential,
     LinearAtomicBaseline,
@@ -212,6 +214,16 @@ def _build_potential_model(model_cfg: ModelConfig, species: Sequence[int]):
             predict_forces=model_cfg.predict_forces,
         )
         return MACEPotential(config)
+    if name == "leftnet":
+        config = LeftNetConfig(
+            species=species_tuple,
+            hidden_dim=model_cfg.hidden_dim,
+            num_layers=model_cfg.leftnet_num_layers,
+            num_radial=model_cfg.leftnet_num_radial,
+            cutoff=model_cfg.cutoff,
+            predict_forces=model_cfg.predict_forces,
+        )
+        return LeftNetPotential(config)
     if name == "gcn":
         config = HybridPotentialConfig(
             species=species_tuple,
@@ -692,6 +704,10 @@ def _train_potential(args: argparse.Namespace) -> None:
         model_overrides["mace_num_layers"] = args.mace_num_layers
     if args.mace_num_radial is not None:
         model_overrides["mace_num_radial"] = args.mace_num_radial
+    if args.leftnet_num_layers is not None:
+        model_overrides["leftnet_num_layers"] = args.leftnet_num_layers
+    if args.leftnet_num_radial is not None:
+        model_overrides["leftnet_num_radial"] = args.leftnet_num_radial
     if args.residual_mode is not None:
         experiment = replace(experiment, model=replace(experiment.model, residual_mode=args.residual_mode))
     if model_overrides:
@@ -1198,7 +1214,8 @@ def build_parser() -> argparse.ArgumentParser:
             "equiformer",
             "equiformer-v2",
             "physnet",
-        "mace",
+            "mace",
+            "leftnet",
         ],
         default=None,
         help="Override the architecture defined in the config (options include transformer, hybrid, se3, and mace variants)",
@@ -1320,6 +1337,18 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Size of the Bessel radial basis used to bias MACE attention",
+    )
+    potential_parser.add_argument(
+        "--leftnet-num-layers",
+        type=int,
+        default=None,
+        help="Number of LEFTNet interaction blocks",
+    )
+    potential_parser.add_argument(
+        "--leftnet-num-radial",
+        type=int,
+        default=None,
+        help="Number of radial basis functions used by LEFTNet",
     )
     coord_group = potential_parser.add_mutually_exclusive_group()
     coord_group.add_argument(

--- a/deltamol/models/__init__.py
+++ b/deltamol/models/__init__.py
@@ -5,6 +5,7 @@ from .dimenet import DimeNetConfig, DimeNetPotential
 from .equiformer_v2 import EquiformerV2Config, EquiformerV2Potential
 from .gemnet import GemNetConfig, GemNetPotential
 from .hybrid import HybridPotential, HybridPotentialConfig
+from .leftnet import LeftNetConfig, LeftNetPotential
 from .mace import MACEConfig, MACEPotential
 from .se3 import SE3TransformerConfig, SE3TransformerPotential
 from .tensornet import TensorNetConfig, TensorNetPotential
@@ -24,6 +25,8 @@ __all__ = [
     "EquiformerV2Potential",
     "GemNetConfig",
     "GemNetPotential",
+    "LeftNetConfig",
+    "LeftNetPotential",
     "TensorNetConfig",
     "TensorNetPotential",
     "MACEConfig",

--- a/deltamol/models/leftnet.py
+++ b/deltamol/models/leftnet.py
@@ -1,0 +1,404 @@
+"""LEFTNet-inspired equivariant potential energy model.
+
+This module adapts the reference implementation from
+`yuanqidu/LeftNet <https://github.com/yuanqidu/LeftNet>`_ to DeltaMol's dense
+batch format. The design couples invariant scalar channels with equivariant
+vector channels, uses local edge and node frames to retain orientational
+information, and supports analytic force computation via energy gradients. The
+implementation keeps the attention-style weighting differentiable even when the
+caller wraps the forward pass in ``torch.no_grad`` by re-enabling gradients for
+force prediction. Gradient-layout hooks keep the DDP bucket formation stable
+when running distributed training.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+def _normalize(vec: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    norm = vec.norm(dim=-1, keepdim=True).clamp(min=eps)
+    return vec / norm
+
+
+class _RadialBasis(nn.Module):
+    """Exponentially spaced radial basis with a smooth cosine cutoff."""
+
+    def __init__(self, num_radial: int, cutoff: float):
+        super().__init__()
+        self.num_radial = num_radial
+        self.cutoff = float(cutoff)
+        start_value = torch.exp(torch.scalar_tensor(-self.cutoff))
+        end_value = torch.exp(torch.scalar_tensor(0.0))
+        means = torch.linspace(start_value, end_value, num_radial)
+        betas = torch.tensor([(2 / max(num_radial, 1) * (end_value - start_value)) ** -2] * num_radial)
+        self.register_buffer("means", means)
+        self.register_buffer("betas", betas)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        scaled = distances.unsqueeze(-1)
+        cutoff = 0.5 * (torch.cos(scaled * math.pi / (self.cutoff + 1e-8)) + 1.0)
+        cutoff = cutoff * (distances < self.cutoff).to(distances.dtype).unsqueeze(-1)
+        exp_term = torch.exp(-scaled)
+        return cutoff * torch.exp(-self.betas * (exp_term - self.means) ** 2)
+
+
+class _NeighborEmbedding(nn.Module):
+    """Aggregate neighbour embeddings weighted by radial filters."""
+
+    def __init__(self, hidden_dim: int, num_species: int):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.embedding = nn.Embedding(num_species + 1, hidden_dim, padding_idx=0)
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        radial_hidden: torch.Tensor,
+        edge_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        neighbour_features = self.embedding(node_indices)  # (B, N, H)
+        weighted = radial_hidden * neighbour_features[:, None, :, :]
+        weighted = weighted * edge_mask.unsqueeze(-1)
+        return weighted.sum(dim=2)
+
+
+class _SubstructureEncoder(nn.Module):
+    """Encode local 3D substructures as vector features."""
+
+    def __init__(self, hidden_dim: int):
+        super().__init__()
+        self.proj = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.SiLU())
+
+    def forward(
+        self,
+        scalar_features: torch.Tensor,
+        displacement: torch.Tensor,
+        radial_hidden: torch.Tensor,
+        edge_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        scalar_features = self.proj(scalar_features)
+        displacement = displacement.unsqueeze(-1) * radial_hidden.unsqueeze(-2)
+        message = displacement * scalar_features[:, None, :, :].unsqueeze(-2)
+        message = message * edge_mask.unsqueeze(-1).unsqueeze(-1)
+        return message.sum(dim=2)  # (B, N, 3, H)
+
+
+class _EquivariantMessagePassing(nn.Module):
+    """Equivariant message passing with distance-aware filters."""
+
+    def __init__(self, hidden_dim: int, num_radial: int):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.inv_proj = nn.Sequential(
+            nn.Linear(hidden_dim * 3 + num_radial, hidden_dim * 3),
+            nn.SiLU(inplace=True),
+            nn.Linear(hidden_dim * 3, hidden_dim * 3),
+        )
+        self.x_proj = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim * 3),
+        )
+        self.rbf_proj = nn.Linear(num_radial, hidden_dim * 3)
+        self.inv_sqrt_3 = 1 / math.sqrt(3.0)
+        self.inv_sqrt_h = 1 / math.sqrt(hidden_dim)
+
+    def forward(
+        self,
+        scalar_features: torch.Tensor,
+        vector_features: torch.Tensor,
+        radial_emb: torch.Tensor,
+        edge_weights: torch.Tensor,
+        displacement: torch.Tensor,
+        edge_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        xh = self.x_proj(scalar_features).view(scalar_features.size(0), scalar_features.size(1), 3, self.hidden_dim)
+        rbfh = self.rbf_proj(radial_emb).view(radial_emb.size(0), radial_emb.size(1), radial_emb.size(2), 3, self.hidden_dim)
+        weight = self.inv_proj(edge_weights).view_as(rbfh)
+        rbfh = rbfh * weight
+
+        xh = xh[:, None, :, :, :]  # (B, 1, N, 3, H)
+        vector_features = vector_features[:, None, :, :, :]  # (B, 1, N, 3, H)
+
+        weighted = xh * rbfh  # (B, N, N, 3, H)
+        scalar_part, scaled_vec, vec_bias = torch.unbind(weighted, dim=3)
+        scaled_vec = scaled_vec * self.inv_sqrt_3
+
+        disp = displacement.unsqueeze(-1)  # (B, N, N, 3, 1)
+        vec_update = vector_features * scaled_vec.unsqueeze(3) + vec_bias.unsqueeze(3) * disp
+        vec_update = vec_update * self.inv_sqrt_h
+
+        scalar_part = scalar_part * edge_mask.unsqueeze(-1)
+        vec_update = vec_update * edge_mask.unsqueeze(-1).unsqueeze(-1)
+
+        scalar_out = scalar_part.sum(dim=2)
+        vec_out = vec_update.sum(dim=2)
+        return scalar_out, vec_out
+
+
+class _FrameTransitionEncoder(nn.Module):
+    """Frame transition encoding to mix scalar and vector channels."""
+
+    def __init__(self, hidden_dim: int):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.equi_proj = nn.Linear(hidden_dim, hidden_dim * 2, bias=False)
+        self.xequi_proj = nn.Sequential(
+            nn.Linear(hidden_dim * 2, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim * 3),
+        )
+        self.inv_sqrt_2 = 1 / math.sqrt(2.0)
+        self.inv_sqrt_h = 1 / math.sqrt(hidden_dim)
+
+    def forward(
+        self,
+        scalar_features: torch.Tensor,
+        vector_features: torch.Tensor,
+        node_frame: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        vec = self.equi_proj(vector_features)
+        vec1, vec2 = torch.split(vec, self.hidden_dim, dim=-1)
+
+        scalar_norm = vec1.norm(dim=-2)
+
+        vec_dot = (vec1 * vec2).sum(dim=2) * self.inv_sqrt_h
+
+        xvec = self.xequi_proj(torch.cat([scalar_features, scalar_norm], dim=-1))
+        xvec1, xvec2, xvec3 = torch.split(xvec, self.hidden_dim, dim=-1)
+
+        dx = (xvec1 + xvec2 + vec_dot) * self.inv_sqrt_2
+        dvec = xvec3.unsqueeze(2) * vec2
+        return dx, dvec
+
+
+class _LeftInteractionBlock(nn.Module):
+    def __init__(self, hidden_dim: int, num_radial: int):
+        super().__init__()
+        self.message = _EquivariantMessagePassing(hidden_dim, num_radial)
+        self.frame_encoder = _FrameTransitionEncoder(hidden_dim)
+
+    def forward(
+        self,
+        scalar_features: torch.Tensor,
+        vector_features: torch.Tensor,
+        radial_emb: torch.Tensor,
+        edge_weights: torch.Tensor,
+        displacement: torch.Tensor,
+        node_frame: torch.Tensor,
+        edge_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ds, dv = self.message(
+            scalar_features,
+            vector_features,
+            radial_emb,
+            edge_weights,
+            displacement,
+            edge_mask,
+        )
+        scalar_features = scalar_features + ds
+        vector_features = vector_features + dv
+        ds, dv = self.frame_encoder(scalar_features, vector_features, node_frame)
+        return scalar_features + ds, vector_features + dv
+
+
+@dataclass
+class LeftNetConfig:
+    """Configuration for :class:`LeftNetPotential`."""
+
+    species: tuple[int, ...]
+    hidden_dim: int = 128
+    num_layers: int = 4
+    num_radial: int = 32
+    cutoff: float = 5.0
+    predict_forces: bool = False
+
+
+class LeftNetPotential(nn.Module):
+    """LEFTNet-style potential energy model."""
+
+    def __init__(self, config: LeftNetConfig):
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+
+        self.radial_basis = _RadialBasis(config.num_radial, config.cutoff)
+        self.radial_lin = nn.Sequential(
+            nn.Linear(config.num_radial, config.hidden_dim),
+            nn.SiLU(inplace=True),
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+        )
+        self.neighbour_emb = _NeighborEmbedding(config.hidden_dim, num_species)
+        self.substructure = _SubstructureEncoder(config.hidden_dim)
+        self.frame_mlp = nn.Sequential(
+            nn.Linear(3, max(config.hidden_dim // 4, 1)),
+            nn.SiLU(inplace=True),
+            nn.Linear(max(config.hidden_dim // 4, 1), 1),
+        )
+        self.layers = nn.ModuleList(
+            [_LeftInteractionBlock(config.hidden_dim, config.num_radial) for _ in range(config.num_layers)]
+        )
+        self.readout = nn.Linear(config.hidden_dim, 1)
+        self.embedding = self.neighbour_emb.embedding
+        self._grad_layout_hook_handle: torch.utils.hooks.RemovableHandle | None = None
+        self._register_grad_layout_hook()
+
+    def _register_grad_layout_hook(self) -> None:
+        """Keep readout gradients contiguous for stable DDP bucket formation."""
+
+        weight = self.readout.weight
+        target_stride = weight.stride()
+
+        def _fix_layout(grad: torch.Tensor | None) -> torch.Tensor | None:
+            if grad is None:
+                return None
+            if grad.stride() != target_stride:
+                return grad.contiguous()
+            return grad
+
+        if self._grad_layout_hook_handle is not None:
+            self._grad_layout_hook_handle.remove()
+        self._grad_layout_hook_handle = weight.register_hook(_fix_layout)
+
+    def refresh_grad_layout_hooks(self) -> None:
+        """Re-register gradient layout hooks after DDP wraps the module."""
+
+        self._register_grad_layout_hook()
+
+    def _build_geometry(
+        self,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor | None,
+        mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        mask_bool = mask.bool()
+        displacement = positions.unsqueeze(2) - positions.unsqueeze(1)
+        distances = torch.linalg.norm(displacement, dim=-1)
+        if adjacency is None:
+            adjacency = (distances <= self.config.cutoff).to(positions.dtype)
+        edge_mask = adjacency.bool() & mask_bool.unsqueeze(1) & mask_bool.unsqueeze(2)
+        eye = torch.eye(edge_mask.size(1), device=edge_mask.device, dtype=torch.bool).unsqueeze(0)
+        edge_mask = edge_mask & ~eye
+
+        displacement = displacement * edge_mask.unsqueeze(-1)
+        safe_distances = distances.clamp(min=1e-6)
+        radial_emb = self.radial_basis(safe_distances) * edge_mask.unsqueeze(-1)
+        radial_hidden = self.radial_lin(radial_emb) * edge_mask.unsqueeze(-1)
+
+        edge_dir = _normalize(displacement + (~edge_mask).unsqueeze(-1) * 0.0)
+        cross = _normalize(
+            torch.cross(positions.unsqueeze(2), positions.unsqueeze(1), dim=-1)
+            + (~edge_mask).unsqueeze(-1) * 0.0
+        )
+        vertical = _normalize(torch.cross(edge_dir, cross, dim=-1) + (~edge_mask).unsqueeze(-1) * 0.0)
+        edge_frame = torch.stack([edge_dir, cross, vertical], dim=-2)  # (B, N, N, 3, 3)
+
+        neighbour_sum = (positions.unsqueeze(1) * edge_mask.unsqueeze(-1)).sum(dim=2)
+        counts = edge_mask.sum(dim=2).clamp(min=1).unsqueeze(-1)
+        mean_neighbor = neighbour_sum / counts
+        node_dir = _normalize(positions - mean_neighbor)
+        node_cross = _normalize(torch.cross(positions, mean_neighbor, dim=-1))
+        node_vertical = _normalize(torch.cross(node_dir, node_cross, dim=-1))
+        node_frame = torch.stack([node_dir, node_cross, node_vertical], dim=-2)  # (B, N, 3, 3)
+
+        return radial_emb, radial_hidden, edge_frame, node_frame
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor | None,
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask_bool = mask.bool()
+        mask_float = mask_bool.float()
+        needs_forces = self.config.predict_forces
+
+        if needs_forces and not positions.requires_grad:
+            positions = positions.detach().clone().requires_grad_(True)
+
+        def _compute_energy(current_positions: torch.Tensor) -> torch.Tensor:
+            radial_emb, radial_hidden, edge_frame, node_frame = self._build_geometry(
+                current_positions, adjacency, mask_bool
+            )
+            displacement = current_positions.unsqueeze(2) - current_positions.unsqueeze(1)
+            displacement = displacement * (radial_emb.sum(dim=-1, keepdim=True) > 0).to(displacement.dtype)
+            soft_cutoff = (radial_emb.sum(dim=-1) > 0).to(current_positions.dtype)
+
+            scalar = self.neighbour_emb(node_indices, radial_hidden, soft_cutoff)
+            scalar = scalar * mask_float.unsqueeze(-1)
+            vector = torch.zeros(
+                (*scalar.shape[:2], 3, scalar.shape[-1]),
+                device=scalar.device,
+                dtype=scalar.dtype,
+            )
+
+            substructure = self.substructure(scalar, displacement, radial_hidden, soft_cutoff)
+            scalrization1 = torch.einsum("bidh,bijdk->bijkh", substructure, edge_frame)
+            scalrization2 = torch.einsum("bjdh,bijdk->bijkh", substructure, edge_frame)
+            scalrization1 = torch.stack(
+                [
+                    scalrization1[:, :, :, 0, :],
+                    scalrization1[:, :, :, 1, :].abs(),
+                    scalrization1[:, :, :, 2, :],
+                ],
+                dim=3,
+            )
+            scalrization2 = torch.stack(
+                [
+                    scalrization2[:, :, :, 0, :],
+                    scalrization2[:, :, :, 1, :].abs(),
+                    scalrization2[:, :, :, 2, :],
+                ],
+                dim=3,
+            )
+
+            scalar3 = self.frame_mlp(scalrization1.permute(0, 1, 2, 4, 3)).squeeze(-1) + scalrization1[:, :, :, 0, :]
+            scalar4 = self.frame_mlp(scalrization2.permute(0, 1, 2, 4, 3)).squeeze(-1) + scalrization2[:, :, :, 0, :]
+            edge_weights = torch.cat([scalar3, scalar4, radial_hidden, radial_emb], dim=-1)
+            edge_weights = edge_weights * soft_cutoff.unsqueeze(-1)
+
+            displacement = _normalize(displacement)
+            displacement = displacement * soft_cutoff.unsqueeze(-1)
+
+            for layer in self.layers:
+                scalar, vector = layer(
+                    scalar,
+                    vector,
+                    radial_emb,
+                    edge_weights,
+                    displacement,
+                    node_frame,
+                    soft_cutoff.bool(),
+                )
+            per_atom = self.readout(scalar).squeeze(-1) * mask_float
+            return per_atom.sum(dim=1)
+
+        forces: torch.Tensor | None = None
+        if needs_forces:
+            with torch.enable_grad():
+                energy = _compute_energy(positions)
+                grads = torch.autograd.grad(
+                    energy.sum(),
+                    positions,
+                    create_graph=self.training,
+                    retain_graph=self.training,
+                    allow_unused=True,
+                )[0]
+            if grads is None:
+                grads = torch.zeros_like(positions)
+            forces = -grads * mask_float.unsqueeze(-1)
+        else:
+            with torch.set_grad_enabled(torch.is_grad_enabled()):
+                energy = _compute_energy(positions)
+
+        return PotentialOutput(energy=energy, forces=forces)
+
+
+__all__ = ["LeftNetConfig", "LeftNetPotential"]

--- a/deltamol/models/leftnet.py
+++ b/deltamol/models/leftnet.py
@@ -278,6 +278,9 @@ class LeftNetPotential(nn.Module):
         mask: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         mask_bool = mask.bool()
+        mask_count = mask_bool.sum(dim=1, keepdim=True).clamp(min=1)
+        centroid = (positions * mask_bool.unsqueeze(-1)).sum(dim=1, keepdim=True) / mask_count
+        centered = positions - centroid
         displacement = positions.unsqueeze(2) - positions.unsqueeze(1)
         distances = torch.linalg.norm(displacement, dim=-1)
         if adjacency is None:
@@ -293,7 +296,7 @@ class LeftNetPotential(nn.Module):
 
         edge_dir = _normalize(displacement + (~edge_mask).unsqueeze(-1) * 0.0)
         cross = _normalize(
-            torch.cross(positions.unsqueeze(2), positions.unsqueeze(1), dim=-1)
+            torch.cross(centered.unsqueeze(2), centered.unsqueeze(1), dim=-1)
             + (~edge_mask).unsqueeze(-1) * 0.0
         )
         vertical = _normalize(torch.cross(edge_dir, cross, dim=-1) + (~edge_mask).unsqueeze(-1) * 0.0)
@@ -303,7 +306,8 @@ class LeftNetPotential(nn.Module):
         counts = edge_mask.sum(dim=2).clamp(min=1).unsqueeze(-1)
         mean_neighbor = neighbour_sum / counts
         node_dir = _normalize(positions - mean_neighbor)
-        node_cross = _normalize(torch.cross(positions, mean_neighbor, dim=-1))
+        centered_mean_neighbor = mean_neighbor - centroid
+        node_cross = _normalize(torch.cross(centered, centered_mean_neighbor, dim=-1))
         node_vertical = _normalize(torch.cross(node_dir, node_cross, dim=-1))
         node_frame = torch.stack([node_dir, node_cross, node_vertical], dim=-2)  # (B, N, 3, 3)
 

--- a/deltamol/training/configs.py
+++ b/deltamol/training/configs.py
@@ -40,6 +40,7 @@ class ModelConfig:
         "transformer",
         "external",
         "hybrid",
+        "leftnet",
         "se3",
         "schnet",
         "dimenet",
@@ -84,6 +85,8 @@ class ModelConfig:
     physnet_num_basis: int = 64
     mace_num_layers: int = 4
     mace_num_radial: int = 16
+    leftnet_num_layers: int = 4
+    leftnet_num_radial: int = 32
 
 
 @dataclass

--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,26 @@ supports analytic force computation via coordinate gradients when
 ``predict_forces`` is enabled. The implementation also installs gradient-layout
 hooks to keep DDP bucket formation stable when running distributed training.
 
+### LEFTNet potential architecture
+
+DeltaMol now integrates a LEFTNet-inspired equivariant potential adapted from
+the reference implementation at `yuanqidu/LeftNet
+<https://github.com/yuanqidu/LeftNet>`_. Select it with ``model.name: leftnet``
+in an experiment YAML or ``--model leftnet`` on the CLI. Key hyperparameters
+include:
+
+* ``leftnet_num_layers`` – number of stacked interaction blocks combining
+  equivariant message passing and frame-transition encoding (default 4).
+* ``leftnet_num_radial`` – number of radial basis functions used to embed
+  interatomic distances with a smooth cutoff (default 32).
+
+LEFTNet mixes invariant scalar features with orientation-aware vector channels,
+builds local frames per edge and per node, and supports analytic force
+computation via energy gradients while keeping attention-style weights
+differentiable even when the forward pass is wrapped in ``torch.no_grad``.
+Gradient-layout hooks keep the final readout contiguous after DDP wrapping to
+avoid bucket formation warnings during distributed training.
+
 ### EquiformerV2 potential architecture
 
 DeltaMol now ships a compact EquiformerV2-style model for equivariant attention

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,3 +126,26 @@ def test_cli_parses_mace_options():
     assert args.model_name == "mace"
     assert args.mace_num_layers == 3
     assert args.mace_num_radial == 24
+
+
+def test_cli_parses_leftnet_options():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "train-potential",
+            "dataset.npz",
+            "--config",
+            "experiment.yaml",
+            "--model",
+            "leftnet",
+            "--leftnet-num-layers",
+            "2",
+            "--leftnet-num-radial",
+            "12",
+        ]
+    )
+
+    assert callable(args.func)
+    assert args.model_name == "leftnet"
+    assert args.leftnet_num_layers == 2
+    assert args.leftnet_num_radial == 12

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from deltamol.models.baseline import build_formula_vector
 from deltamol.models.equiformer_v2 import EquiformerV2Config, EquiformerV2Potential
 from deltamol.models.gemnet import GemNetConfig, GemNetPotential
 from deltamol.models.hybrid import HybridPotential, HybridPotentialConfig
+from deltamol.models.leftnet import LeftNetConfig, LeftNetPotential
 from deltamol.models.mace import MACEConfig, MACEPotential
 from deltamol.models.se3 import SE3TransformerConfig, SE3TransformerPotential
 from deltamol.models.tensornet import TensorNetConfig, TensorNetPotential
@@ -519,3 +520,29 @@ def test_equiformer_v2_energy_dependent_on_coordinates():
     grad = torch.autograd.grad(energy, positions)[0]
 
     assert torch.max(torch.abs(grad)) > 0
+
+
+def test_leftnet_forward_and_forces():
+    torch.manual_seed(0)
+    species = (1, 6)
+    config = LeftNetConfig(
+        species=species,
+        hidden_dim=16,
+        num_layers=1,
+        num_radial=6,
+        cutoff=4.0,
+        predict_forces=True,
+    )
+    model = LeftNetPotential(config)
+    node_indices = torch.tensor([[1, 2, 0]], dtype=torch.long)
+    positions = torch.tensor([[[0.0, 0.0, 0.0], [1.0, 0.4, -0.2], [0.2, -0.1, 0.3]]])
+    adjacency = torch.tensor([[[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]]])
+    mask = node_indices != 0
+
+    with torch.no_grad():
+        output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (1,)
+    assert output.forces is not None
+    assert output.forces.shape == positions.shape
+    assert torch.all(torch.isfinite(output.forces))


### PR DESCRIPTION
## Summary
- add a LEFTNet-inspired potential implementation with DDP-safe gradient handling and analytic forces
- wire the training/CLI model configuration to expose leftnet hyperparameters and build the new model
- document the leftnet option and cover it with CLI and force-shape tests

## Testing
- python -m pytest tests/test_models.py::test_leftnet_forward_and_forces tests/test_cli.py::test_cli_parses_leftnet_options

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b44169e8832f870dcd2b13621ca9)