### PR TITLE
Add LiteFusion potential model

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ configuration:
 Architectures can be swapped without editing the YAML by passing
 `--model transformer`, `--model hybrid`, `--model schnet`, `--model dimenet`,
 `--model gemnet`, `--model tensornet`, `--model se3`, `--model physnet`,
-`--model equiformer_v2`, or `--model mace` on the CLI; the flag respects the
+`--model equiformer_v2`, `--model mace`, or `--model litefusion` on the CLI; the flag respects the
 same residual training flow used by the baseline so SE(3) Transformer runs
 participate in delta-learning alongside the hybrid potential. Additional overrides for depth (`--transformer-layers`,
 `--gcn-layers`, `--se3-layers`), width (`--hidden-dim`, `--ffn-dim`,
@@ -391,6 +391,25 @@ the energy gradient even inside `torch.no_grad()` contexts, keeping attention
 gradients intact. A lightweight gradient-layout hook keeps the readout weights
 contiguous after DDP wraps the model so bucket formation remains stable in
 multi-GPU runs.
+
+The LiteFusion option blends mixed radial basis expansions, directional edge
+features, and distance-aware attention into a lightweight architecture. Choose
+`model.name: litefusion` or `--model litefusion` and configure it with:
+
+* `--litefusion-num-blocks` (`model.litefusion_num_blocks`) – number of stacked
+  attention blocks (default 3).
+* `--litefusion-num-radial` (`model.litefusion_num_radial`) – Bessel radial
+  basis size for distance expansion (default 6).
+* `--litefusion-num-gaussians` (`model.litefusion_num_gaussians`) – Gaussian
+  radial basis size for distance expansion (default 6).
+* `--litefusion-num-spherical` (`model.litefusion_num_spherical`) – number of
+  directional projections used to encode edge orientations (default 4).
+* `--litefusion-rbf-dim` (`model.litefusion_rbf_dim`) – hidden dimension for the
+  fused radial embedding (default 32).
+
+LiteFusion reuses the shared `hidden_dim`, `num_heads`, `dropout`, and `cutoff`
+settings, and supports analytic force prediction via energy gradients when
+`predict_forces` is enabled.
 
 Dataset sections inside the experiment configuration accept the same `format`
 and `key_map` fields exposed on the CLI. Each `key_map` entry follows the

--- a/deltamol/cli/__init__.py
+++ b/deltamol/cli/__init__.py
@@ -40,6 +40,8 @@ from ..models import (
     EquiformerV2Potential,
     GemNetConfig,
     GemNetPotential,
+    LiteFusionConfig,
+    LiteFusionPotential,
     MACEConfig,
     MACEPotential,
     LeftNetConfig,
@@ -214,6 +216,21 @@ def _build_potential_model(model_cfg: ModelConfig, species: Sequence[int]):
             predict_forces=model_cfg.predict_forces,
         )
         return MACEPotential(config)
+    if name == "litefusion":
+        config = LiteFusionConfig(
+            species=species_tuple,
+            hidden_dim=model_cfg.hidden_dim,
+            num_blocks=model_cfg.litefusion_num_blocks,
+            num_heads=model_cfg.num_heads,
+            num_radial=model_cfg.litefusion_num_radial,
+            num_gaussians=model_cfg.litefusion_num_gaussians,
+            num_spherical=model_cfg.litefusion_num_spherical,
+            rbf_dim=model_cfg.litefusion_rbf_dim,
+            cutoff=model_cfg.cutoff,
+            dropout=model_cfg.dropout,
+            predict_forces=model_cfg.predict_forces,
+        )
+        return LiteFusionPotential(config)
     if name == "leftnet":
         config = LeftNetConfig(
             species=species_tuple,
@@ -708,6 +725,16 @@ def _train_potential(args: argparse.Namespace) -> None:
         model_overrides["leftnet_num_layers"] = args.leftnet_num_layers
     if args.leftnet_num_radial is not None:
         model_overrides["leftnet_num_radial"] = args.leftnet_num_radial
+    if args.litefusion_num_blocks is not None:
+        model_overrides["litefusion_num_blocks"] = args.litefusion_num_blocks
+    if args.litefusion_num_radial is not None:
+        model_overrides["litefusion_num_radial"] = args.litefusion_num_radial
+    if args.litefusion_num_gaussians is not None:
+        model_overrides["litefusion_num_gaussians"] = args.litefusion_num_gaussians
+    if args.litefusion_num_spherical is not None:
+        model_overrides["litefusion_num_spherical"] = args.litefusion_num_spherical
+    if args.litefusion_rbf_dim is not None:
+        model_overrides["litefusion_rbf_dim"] = args.litefusion_rbf_dim
     if args.residual_mode is not None:
         experiment = replace(experiment, model=replace(experiment.model, residual_mode=args.residual_mode))
     if model_overrides:
@@ -1216,6 +1243,7 @@ def build_parser() -> argparse.ArgumentParser:
             "physnet",
             "mace",
             "leftnet",
+            "litefusion",
         ],
         default=None,
         help="Override the architecture defined in the config (options include transformer, hybrid, se3, and mace variants)",
@@ -1349,6 +1377,36 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Number of radial basis functions used by LEFTNet",
+    )
+    potential_parser.add_argument(
+        "--litefusion-num-blocks",
+        type=int,
+        default=None,
+        help="Number of LiteFusion attention blocks",
+    )
+    potential_parser.add_argument(
+        "--litefusion-num-radial",
+        type=int,
+        default=None,
+        help="Size of the Bessel radial basis for LiteFusion",
+    )
+    potential_parser.add_argument(
+        "--litefusion-num-gaussians",
+        type=int,
+        default=None,
+        help="Size of the Gaussian radial basis for LiteFusion",
+    )
+    potential_parser.add_argument(
+        "--litefusion-num-spherical",
+        type=int,
+        default=None,
+        help="Number of directional projections for LiteFusion edge features",
+    )
+    potential_parser.add_argument(
+        "--litefusion-rbf-dim",
+        type=int,
+        default=None,
+        help="Hidden dimension of the fused radial embedding for LiteFusion",
     )
     coord_group = potential_parser.add_mutually_exclusive_group()
     coord_group.add_argument(

--- a/deltamol/models/__init__.py
+++ b/deltamol/models/__init__.py
@@ -6,6 +6,7 @@ from .equiformer_v2 import EquiformerV2Config, EquiformerV2Potential
 from .gemnet import GemNetConfig, GemNetPotential
 from .hybrid import HybridPotential, HybridPotentialConfig
 from .leftnet import LeftNetConfig, LeftNetPotential
+from .litefusion import LiteFusionConfig, LiteFusionPotential
 from .mace import MACEConfig, MACEPotential
 from .se3 import SE3TransformerConfig, SE3TransformerPotential
 from .tensornet import TensorNetConfig, TensorNetPotential
@@ -27,6 +28,8 @@ __all__ = [
     "GemNetPotential",
     "LeftNetConfig",
     "LeftNetPotential",
+    "LiteFusionConfig",
+    "LiteFusionPotential",
     "TensorNetConfig",
     "TensorNetPotential",
     "MACEConfig",

--- a/deltamol/models/litefusion.py
+++ b/deltamol/models/litefusion.py
@@ -127,7 +127,7 @@ class LiteFusionBlock(nn.Module):
         edge_update = edge_update.view(B, N, N, self.num_heads, self.head_dim)
         edge_update = edge_update * edge_mask.unsqueeze(-1).unsqueeze(-1)
 
-        edge_values = v.unsqueeze(2) * (1.0 + edge_update)
+        edge_values = v.unsqueeze(1) * (1.0 + edge_update)
         edge_values = edge_values.permute(0, 3, 1, 2, 4)
         context = torch.einsum("bhij,bhijd->bihd", attn, edge_values)
         context = context.reshape(B, N, self.hidden_dim)

--- a/deltamol/models/litefusion.py
+++ b/deltamol/models/litefusion.py
@@ -1,0 +1,264 @@
+"""LiteFusion potential energy model.
+
+This lightweight architecture blends directional edge features, mixed radial
+embeddings, and distance-aware attention into a compact potential suitable for
+energy and force prediction. The design fuses ideas from radial basis
+expansions, directional message passing, and attention-style aggregation while
+staying lightweight for experimentation.
+"""
+from __future__ import annotations
+
+import math
+from contextlib import nullcontext
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from .potential import PotentialOutput
+
+
+class BesselRadialBasis(nn.Module):
+    """Expand distances with a sinusoidal Bessel basis and smooth cutoff."""
+
+    def __init__(self, num_radial: int, cutoff: float):
+        super().__init__()
+        self.num_radial = num_radial
+        self.cutoff = float(cutoff)
+        freqs = torch.arange(1, num_radial + 1, dtype=torch.float32)
+        self.register_buffer("freqs", freqs)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        scaled = distances / (self.cutoff + 1e-8)
+        safe_dist = distances.clamp(min=1e-6)
+        angles = math.pi * scaled.unsqueeze(-1) * self.freqs
+        basis = torch.sin(angles) / safe_dist.unsqueeze(-1)
+        cutoff_envelope = 0.5 * (torch.cos(math.pi * scaled) + 1.0)
+        cutoff_envelope = cutoff_envelope * (distances <= self.cutoff).to(distances.dtype)
+        return basis * cutoff_envelope.unsqueeze(-1)
+
+
+class GaussianRadialBasis(nn.Module):
+    """Expand distances with Gaussian basis functions."""
+
+    def __init__(self, cutoff: float, num_gaussians: int):
+        super().__init__()
+        centers = torch.linspace(0.0, cutoff, num_gaussians)
+        self.register_buffer("centers", centers)
+        self.width = cutoff / max(num_gaussians, 1)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple math
+        diff = distances.unsqueeze(-1) - self.centers
+        return torch.exp(-0.5 * (diff / (self.width + 1e-8)) ** 2)
+
+
+class LiteFusionBlock(nn.Module):
+    """Distance-aware attention block with directional gating."""
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        num_heads: int,
+        rbf_dim: int,
+        direction_dim: int,
+        dropout: float,
+    ) -> None:
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.scale = math.sqrt(self.head_dim)
+
+        self.qkv = nn.Linear(hidden_dim, hidden_dim * 3)
+        self.attn_bias = nn.Sequential(
+            nn.Linear(rbf_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, num_heads),
+        )
+        self.edge_mlp = nn.Sequential(
+            nn.Linear(rbf_dim + direction_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+        )
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.norm1 = nn.LayerNorm(hidden_dim)
+        self.norm2 = nn.LayerNorm(hidden_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.ff = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim * 2),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim * 2, hidden_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        radial_features: torch.Tensor,
+        direction_features: torch.Tensor,
+        edge_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        B, N, _ = features.shape
+        residual = features
+        features = self.norm1(features)
+
+        qkv = self.qkv(features)
+        q, k, v = qkv.chunk(3, dim=-1)
+        q = q.view(B, N, self.num_heads, self.head_dim)
+        k = k.view(B, N, self.num_heads, self.head_dim)
+        v = v.view(B, N, self.num_heads, self.head_dim)
+
+        logits = torch.einsum("bihd,bjhd->bhij", q, k) / self.scale
+        bias = self.attn_bias(radial_features)
+        logits = logits + bias.permute(0, 3, 1, 2)
+
+        masked_logits = logits.masked_fill(
+            ~edge_mask.unsqueeze(1), torch.finfo(logits.dtype).min
+        )
+        attn = torch.softmax(masked_logits, dim=-1)
+        attn = torch.nan_to_num(attn, nan=0.0)
+        attn = self.dropout(attn)
+
+        edge_inputs = torch.cat([radial_features, direction_features], dim=-1)
+        edge_update = self.edge_mlp(edge_inputs)
+        edge_update = edge_update.view(B, N, N, self.num_heads, self.head_dim)
+        edge_update = edge_update * edge_mask.unsqueeze(-1).unsqueeze(-1)
+
+        edge_values = v.unsqueeze(2) * (1.0 + edge_update)
+        edge_values = edge_values.permute(0, 3, 1, 2, 4)
+        context = torch.einsum("bhij,bhijd->bihd", attn, edge_values)
+        context = context.reshape(B, N, self.hidden_dim)
+
+        features = residual + self.dropout(self.out_proj(context))
+        features = features + self.ff(self.norm2(features))
+        return features
+
+
+@dataclass
+class LiteFusionConfig:
+    """Configuration for :class:`LiteFusionPotential`."""
+
+    species: tuple[int, ...]
+    hidden_dim: int = 128
+    num_blocks: int = 3
+    num_heads: int = 4
+    num_radial: int = 6
+    num_gaussians: int = 6
+    num_spherical: int = 4
+    rbf_dim: int = 32
+    cutoff: float = 5.0
+    dropout: float = 0.1
+    predict_forces: bool = False
+
+
+class LiteFusionPotential(nn.Module):
+    """LiteFusion potential with radial fusion and directional attention."""
+
+    def __init__(self, config: LiteFusionConfig) -> None:
+        super().__init__()
+        self.config = config
+        num_species = len(config.species)
+
+        self.embedding = nn.Embedding(num_species + 1, config.hidden_dim, padding_idx=0)
+        self.bessel_basis = BesselRadialBasis(config.num_radial, config.cutoff)
+        self.gaussian_basis = GaussianRadialBasis(config.cutoff, config.num_gaussians)
+        self.radial_fusion = nn.Sequential(
+            nn.Linear(config.num_radial + config.num_gaussians, config.rbf_dim),
+            nn.SiLU(),
+            nn.Linear(config.rbf_dim, config.rbf_dim),
+        )
+        self.direction_proj = nn.Linear(3, config.num_spherical)
+
+        self.blocks = nn.ModuleList(
+            [
+                LiteFusionBlock(
+                    hidden_dim=config.hidden_dim,
+                    num_heads=config.num_heads,
+                    rbf_dim=config.rbf_dim,
+                    direction_dim=config.num_spherical,
+                    dropout=config.dropout,
+                )
+                for _ in range(config.num_blocks)
+            ]
+        )
+        self.readout = nn.Sequential(
+            nn.LayerNorm(config.hidden_dim),
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.SiLU(),
+            nn.Linear(config.hidden_dim, 1),
+        )
+
+    def _build_geometry(
+        self,
+        positions: torch.Tensor,
+        mask: torch.Tensor,
+        adjacency: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        mask_bool = mask.bool()
+        displacement = positions.unsqueeze(2) - positions.unsqueeze(1)
+        distances = torch.linalg.norm(displacement, dim=-1)
+
+        edge_mask = mask_bool.unsqueeze(1) & mask_bool.unsqueeze(2)
+        cutoff_mask = distances <= self.config.cutoff
+        edge_mask = edge_mask & cutoff_mask
+        if adjacency is not None:
+            edge_mask = edge_mask & adjacency.bool()
+
+        eye = torch.eye(edge_mask.size(1), device=edge_mask.device, dtype=torch.bool)
+        edge_mask = edge_mask & ~eye.unsqueeze(0)
+        has_edges = edge_mask.any(dim=-1)
+        isolated = mask_bool & ~has_edges
+        if isolated.any():
+            edge_mask = edge_mask | torch.diag_embed(isolated)
+        distances = distances.clamp(min=1e-6)
+        return displacement, distances, edge_mask
+
+    def forward(
+        self,
+        node_indices: torch.Tensor,
+        positions: torch.Tensor,
+        adjacency: torch.Tensor | None,
+        mask: torch.Tensor,
+    ) -> PotentialOutput:
+        mask_bool = mask.bool()
+        mask_float = mask_bool.float()
+
+        if self.config.predict_forces and not positions.requires_grad:
+            positions = positions.clone().detach().requires_grad_(True)
+
+        grad_context = nullcontext()
+        if self.config.predict_forces and not torch.is_grad_enabled():
+            grad_context = torch.enable_grad()
+
+        with grad_context:
+            displacement, distances, edge_mask = self._build_geometry(positions, mask_bool, adjacency)
+
+            direction = displacement / (distances.unsqueeze(-1) + 1e-8)
+            direction = direction * edge_mask.unsqueeze(-1)
+            direction_features = torch.tanh(self.direction_proj(direction))
+
+            bessel = self.bessel_basis(distances)
+            gaussian = self.gaussian_basis(distances)
+            radial_raw = torch.cat([bessel, gaussian], dim=-1)
+            radial_features = self.radial_fusion(radial_raw)
+            radial_features = radial_features * edge_mask.unsqueeze(-1)
+
+            features = self.embedding(node_indices) * mask_float.unsqueeze(-1)
+            for block in self.blocks:
+                features = block(features, radial_features, direction_features, edge_mask)
+
+            per_atom_energy = self.readout(features).squeeze(-1) * mask_float
+            energy = per_atom_energy.sum(dim=1)
+
+            forces = None
+            if self.config.predict_forces:
+                forces = -torch.autograd.grad(energy.sum(), positions, create_graph=self.training)[0]
+                forces = forces * mask_float.unsqueeze(-1)
+
+        return PotentialOutput(energy=energy, forces=forces)
+
+
+__all__ = ["LiteFusionConfig", "LiteFusionPotential"]

--- a/deltamol/training/configs.py
+++ b/deltamol/training/configs.py
@@ -49,6 +49,7 @@ class ModelConfig:
         "tensornet",
         "physnet",
         "mace",
+        "litefusion",
     ] = "transformer"
     hidden_dim: int = 128
     gcn_layers: int = 2
@@ -87,6 +88,11 @@ class ModelConfig:
     mace_num_radial: int = 16
     leftnet_num_layers: int = 4
     leftnet_num_radial: int = 32
+    litefusion_num_blocks: int = 3
+    litefusion_num_radial: int = 6
+    litefusion_num_gaussians: int = 6
+    litefusion_num_spherical: int = 4
+    litefusion_rbf_dim: int = 32
 
 
 @dataclass

--- a/docs/index.md
+++ b/docs/index.md
@@ -150,6 +150,29 @@ under ``torch.no_grad`` contexts. A small gradient-layout hook keeps the final
 readout weights contiguous after wrapping with DDP so bucket formation remains
 stable during distributed training.
 
+### LiteFusion potential architecture
+
+DeltaMol also includes a LiteFusion potential that blends radial basis fusion,
+directional edge features, and distance-aware attention into a compact model
+suited for efficient experimentation. Select it with ``model.name: litefusion``
+in an experiment YAML or ``--model litefusion`` on the CLI. Core hyperparameters
+include:
+
+* ``litefusion_num_blocks`` – number of attention blocks stacked sequentially
+  (default 3).
+* ``litefusion_num_radial`` – Bessel radial basis size for distance expansion
+  (default 6).
+* ``litefusion_num_gaussians`` – Gaussian radial basis size for distance
+  expansion (default 6).
+* ``litefusion_num_spherical`` – number of directional projections used to
+  encode edge orientation (default 4).
+* ``litefusion_rbf_dim`` – hidden dimension for the fused radial embedding
+  (default 32).
+
+LiteFusion reuses the shared ``hidden_dim``, ``num_heads``, ``dropout``, and
+``cutoff`` settings. When ``predict_forces`` is enabled, it provides analytic
+forces via gradients of the summed energy with respect to atomic coordinates.
+
 ### PhysNet potential architecture
 
 DeltaMol now includes a compact PhysNet-inspired architecture adapted from the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,3 +149,35 @@ def test_cli_parses_leftnet_options():
     assert args.model_name == "leftnet"
     assert args.leftnet_num_layers == 2
     assert args.leftnet_num_radial == 12
+
+
+def test_cli_parses_litefusion_options():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "train-potential",
+            "dataset.npz",
+            "--config",
+            "experiment.yaml",
+            "--model",
+            "litefusion",
+            "--litefusion-num-blocks",
+            "2",
+            "--litefusion-num-radial",
+            "8",
+            "--litefusion-num-gaussians",
+            "10",
+            "--litefusion-num-spherical",
+            "3",
+            "--litefusion-rbf-dim",
+            "24",
+        ]
+    )
+
+    assert callable(args.func)
+    assert args.model_name == "litefusion"
+    assert args.litefusion_num_blocks == 2
+    assert args.litefusion_num_radial == 8
+    assert args.litefusion_num_gaussians == 10
+    assert args.litefusion_num_spherical == 3
+    assert args.litefusion_rbf_dim == 24

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from deltamol.models.equiformer_v2 import EquiformerV2Config, EquiformerV2Potent
 from deltamol.models.gemnet import GemNetConfig, GemNetPotential
 from deltamol.models.hybrid import HybridPotential, HybridPotentialConfig
 from deltamol.models.leftnet import LeftNetConfig, LeftNetPotential
+from deltamol.models.litefusion import LiteFusionConfig, LiteFusionPotential
 from deltamol.models.mace import MACEConfig, MACEPotential
 from deltamol.models.se3 import SE3TransformerConfig, SE3TransformerPotential
 from deltamol.models.tensornet import TensorNetConfig, TensorNetPotential
@@ -231,6 +232,35 @@ def test_mace_forward_pass_runs():
         predict_forces=True,
     )
     model = MACEPotential(config)
+    node_indices = torch.tensor([[1, 2, 3, 0], [3, 1, 0, 0]], dtype=torch.long)
+    positions = torch.randn(2, 4, 3)
+    adjacency = torch.eye(4).repeat(2, 1, 1)
+    mask = node_indices != 0
+
+    output = model(node_indices, positions, adjacency, mask)
+
+    assert output.energy.shape == (2,)
+    assert output.forces is not None
+    assert output.forces.shape == (2, 4, 3)
+
+
+def test_litefusion_forward_pass_runs():
+    torch.manual_seed(0)
+    species = (1, 6, 8)
+    config = LiteFusionConfig(
+        species=species,
+        hidden_dim=32,
+        num_blocks=2,
+        num_heads=4,
+        num_radial=6,
+        num_gaussians=6,
+        num_spherical=4,
+        rbf_dim=16,
+        cutoff=3.5,
+        dropout=0.0,
+        predict_forces=True,
+    )
+    model = LiteFusionPotential(config)
     node_indices = torch.tensor([[1, 2, 3, 0], [3, 1, 0, 0]], dtype=torch.long)
     positions = torch.randn(2, 4, 3)
     adjacency = torch.eye(4).repeat(2, 1, 1)


### PR DESCRIPTION
### Motivation
- Provide a compact, experiment-friendly potential that fuses Bessel and Gaussian radial embeddings with directional edge features and distance-aware attention for efficient energy and force prediction.

### Description
- Add `deltamol/models/litefusion.py` implementing `LiteFusionConfig`, `LiteFusionPotential`, `LiteFusionBlock`, `BesselRadialBasis`, and `GaussianRadialBasis` to perform radial fusion and attention-style aggregation.
- Wire LiteFusion into the model factory and public API by updating `deltamol/models/__init__.py` and integrate configuration defaults in `deltamol/training/configs.py` (new `litefusion_*` fields).
- Expose CLI overrides in `deltamol/cli/__init__.py` (`--litefusion-*` flags) and add a factory branch to return `LiteFusionPotential` when `model.name == "litefusion"`.
- Update user-facing docs in `README.md` and `docs/index.md` and add unit tests in `tests/test_models.py` and `tests/test_cli.py` to cover the model forward pass and CLI parsing.

### Testing
- Executed `pytest tests/test_models.py::test_litefusion_forward_pass_runs tests/test_cli.py::test_cli_parses_litefusion_options` and both tests passed (`2 passed`).
- The new tests exercise a forward pass that returns `energy` and `forces` shapes and CLI parsing for the new `--litefusion-*` flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973120c8da4832f9578e843f7dfd1e1)